### PR TITLE
Adds Github Actions autobuild and build check

### DIFF
--- a/.github/actions/check-build/action.yaml
+++ b/.github/actions/check-build/action.yaml
@@ -1,0 +1,34 @@
+name: Check build
+description: Ensures that the site will build, preventing garbage from being deployed
+inputs:
+  generate_artifact:
+    description: Whether or not to generate a build artifact for eventual publication
+    required: false
+    default: "false"
+outputs:
+  artifact_name:
+    description: "The name of the artifact"
+    value: "gh-pages-artifact"
+runs:
+  using: composite
+  steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Set up nodejs
+      uses: actions/setup-node@v3
+      with:
+        node-version: 19
+    - name: Install dependencies
+      shell: bash
+      run: npm install
+    - name: Build site
+      shell: bash
+      run: npm run build
+    - name: Upload build artifact
+      if: ${{ inputs.generate_artifact != 'false' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: gh-pages-artifact
+        path: build
+        retention-days: 1
+

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -1,0 +1,16 @@
+on:
+  pull_request: ~
+  push:
+    branches-ignore:
+      - master
+      - gh-pages
+name: Check build (non-master)
+jobs:
+  check-build:
+    runs-on: ubuntu-latest
+    name: Check build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Check build and create artifact
+        uses: ./.github/actions/check-build

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -1,0 +1,36 @@
+name: Master build and deploy
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - public/**
+      - src/**
+      - package-lock.json
+      - tsconfig.json
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy site
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Check build and create artifact
+        id: create-artifact
+        uses: ./.github/actions/check-build
+        with:
+          generate_artifact: "true"
+      - name: Fetch artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ steps.create-artifact.outputs.artifact-name }}
+          path: build
+      - name: Set up nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 19
+      - name: Publish github pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "scripts": {
         "predeploy": "npm run build",
         "deploy": "gh-pages -d build",
+        "master_deploy": "gh-pages -d build -- -u \"github-actions-bot <support+actions@github.com>\"",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",


### PR DESCRIPTION
This adds some extra Github Actions setup to automatically commit to the gh-pages branch any time `master` receives a commit. It will also check any other branch that receives commits to see if the build is successful. (Also checks pull requests.) 

To enable, you need to make two repository settings changes. Go to the Actions section and turn on "Read and write permissions" for workflows:

![image](https://github.com/chartanon/moechart/assets/133459670/6fde20da-7483-4743-b5b2-b1a84cb5322e)

You also need to adjust the Pages settings to pull directly from a branch instead of using the built-in Jekyll action:

![image](https://github.com/chartanon/moechart/assets/133459670/d4cfcea1-6b3a-4d33-bc6b-c46c00946f55)
