### PR TITLE
Feature/add-recommended-vns

### DIFF
--- a/src/views/HomePage/Chart/ChartEntry.tsx
+++ b/src/views/HomePage/Chart/ChartEntry.tsx
@@ -11,7 +11,7 @@ import { VisualNovelCard } from './VisualNovelCard';
 
 export interface ChartEntryProps extends VisualNovelProps {
     allSequelRelationships?: SeriesRelationshipMap;
-    isSelectedHideSequelFilter?: boolean;
+    isSelectedShowSequelFilter?: boolean;
     setIsInPopupView?: (value: boolean) => void;
     shouldDisplayDateInTitle?: boolean;
 }
@@ -22,7 +22,7 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
         genreFocus,
         sequels,
         allSequelRelationships,
-        isSelectedHideSequelFilter,
+        isSelectedShowSequelFilter,
         setIsInPopupView,
         shouldDisplayDateInTitle
     } = props;
@@ -83,7 +83,7 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
                     isVNWithSequels ? handleSetShowMoreSequelInfo : undefined
                 }
             />
-            {isVNWithSequels && isSelectedHideSequelFilter ? (
+            {isVNWithSequels && !isSelectedShowSequelFilter ? (
                 <SequelRow>
                     {allSequelRelationships[vndbLink].map(
                         (relationship, index) => (

--- a/src/views/HomePage/Chart/ChartEntry.tsx
+++ b/src/views/HomePage/Chart/ChartEntry.tsx
@@ -28,6 +28,7 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
         shouldDisplayDateInTitle,
         isRecommended
     } = props;
+
     let outlineColour = COLOURS.GENRE.NUKIGE;
     switch (genreFocus) {
         case GenreFocus.COMEDY:
@@ -95,6 +96,8 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
                 <RecommendedPopup
                     isOpen={shouldShowRecommendedInfo}
                     onClose={handleCloseRecommendedInfo}
+                    outlineColour={outlineColour}
+                    {...props}
                 />
             ) : null}
             <VisualNovelCard

--- a/src/views/HomePage/Chart/ChartEntry.tsx
+++ b/src/views/HomePage/Chart/ChartEntry.tsx
@@ -16,23 +16,16 @@ export interface ChartEntryProps extends VisualNovelProps {
     shouldDisplayDateInTitle?: boolean;
 }
 
-export const ChartEntry: React.FC<ChartEntryProps> = ({
-    name,
-    vndbLink,
-    playtime,
-    thumbnailSource,
-    attributes,
-    genreFocus,
-    descriptionFirstRowText,
-    descriptionSecondRowText,
-    sequels,
-    originalGame,
-    allSequelRelationships,
-    isSelectedHideSequelFilter,
-    setIsInPopupView,
-    shouldDisplayDateInTitle,
-    translationReleaseDate
-}) => {
+export const ChartEntry: React.FC<ChartEntryProps> = props => {
+    const {
+        vndbLink,
+        genreFocus,
+        sequels,
+        allSequelRelationships,
+        isSelectedHideSequelFilter,
+        setIsInPopupView,
+        shouldDisplayDateInTitle
+    } = props;
     let outlineColour = COLOURS.GENRE.NUKIGE;
     switch (genreFocus) {
         case GenreFocus.COMEDY:
@@ -84,23 +77,11 @@ export const ChartEntry: React.FC<ChartEntryProps> = ({
                     shouldDisplayDateInTitle={shouldDisplayDateInTitle}
                 />
             ) : null}
-
             <VisualNovelCard
-                name={name}
-                vndbLink={vndbLink}
-                thumbnailSource={thumbnailSource}
-                attributes={attributes}
-                genreFocus={genreFocus}
-                descriptionFirstRowText={descriptionFirstRowText}
-                descriptionSecondRowText={descriptionSecondRowText}
-                playtime={playtime}
-                sequels={sequels}
-                originalGame={originalGame}
+                {...props}
                 moreInfoOnClick={
                     isVNWithSequels ? handleSetShowMoreSequelInfo : undefined
                 }
-                shouldDisplayDateInTitle={shouldDisplayDateInTitle}
-                translationReleaseDate={translationReleaseDate}
             />
             {isVNWithSequels && isSelectedHideSequelFilter ? (
                 <SequelRow>
@@ -115,6 +96,7 @@ export const ChartEntry: React.FC<ChartEntryProps> = ({
                                     $outlineColour={outlineColour}
                                     $index={index}
                                     $cardStackCount={sequels?.length}
+                                    $shouldScaleSize={!!sequels?.length}
                                 />
                             </Row>
                         )

--- a/src/views/HomePage/Chart/ChartEntry.tsx
+++ b/src/views/HomePage/Chart/ChartEntry.tsx
@@ -8,6 +8,7 @@ import { SequelsPopup } from './SequelsPopup';
 import { IMAGE_WIDTH, SEQUELS_OFFSET, ThumbnailImage } from './utils';
 import { GenreFocus } from './utils';
 import { VisualNovelCard } from './VisualNovelCard';
+import { RecommendedPopup } from './RecommendedPopup';
 
 export interface ChartEntryProps extends VisualNovelProps {
     allSequelRelationships?: SeriesRelationshipMap;
@@ -24,7 +25,8 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
         allSequelRelationships,
         isSelectedShowSequelFilter,
         setIsInPopupView,
-        shouldDisplayDateInTitle
+        shouldDisplayDateInTitle,
+        isRecommended
     } = props;
     let outlineColour = COLOURS.GENRE.NUKIGE;
     switch (genreFocus) {
@@ -56,13 +58,26 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
     const [shouldShowSequelInfo, setShouldShowSequelInfo] =
         useState<boolean>(false);
 
-    const handleSetShowMoreSequelInfo = () => {
+    const [shouldShowRecommendedInfo, setShouldShowRecommendedInfo] =
+        useState<boolean>(false);
+
+    const handleShowMoreSequelInfo = () => {
         setShouldShowSequelInfo(true);
         setIsInPopupView?.(true);
     };
 
-    const handleCloseShowMoreSequelInfo = () => {
+    const handleCloseMoreSequelInfo = () => {
         setShouldShowSequelInfo(false);
+        setIsInPopupView?.(false);
+    };
+
+    const handleShowRecommendedInfo = () => {
+        setShouldShowRecommendedInfo(true);
+        setIsInPopupView?.(true);
+    };
+
+    const handleCloseRecommendedInfo = () => {
+        setShouldShowRecommendedInfo(false);
         setIsInPopupView?.(false);
     };
 
@@ -71,16 +86,24 @@ export const ChartEntry: React.FC<ChartEntryProps> = props => {
             {shouldShowSequelInfo ? (
                 <SequelsPopup
                     isOpen={shouldShowSequelInfo}
-                    onClose={handleCloseShowMoreSequelInfo}
-                    originalGame={vndbLink}
-                    allSequelRelations={allSequelRelationships ?? {}}
+                    onClose={handleCloseMoreSequelInfo}
+                    sequelRelations={allSequelRelationships?.[vndbLink] ?? []}
                     shouldDisplayDateInTitle={shouldDisplayDateInTitle}
+                />
+            ) : null}
+            {shouldShowRecommendedInfo ? (
+                <RecommendedPopup
+                    isOpen={shouldShowRecommendedInfo}
+                    onClose={handleCloseRecommendedInfo}
                 />
             ) : null}
             <VisualNovelCard
                 {...props}
-                moreInfoOnClick={
-                    isVNWithSequels ? handleSetShowMoreSequelInfo : undefined
+                sequelInfoOnClick={
+                    isVNWithSequels ? handleShowMoreSequelInfo : undefined
+                }
+                descriptionInfoOnClick={
+                    isRecommended ? handleShowRecommendedInfo : undefined
                 }
             />
             {isVNWithSequels && !isSelectedShowSequelFilter ? (

--- a/src/views/HomePage/Chart/ChartEntry.tsx
+++ b/src/views/HomePage/Chart/ChartEntry.tsx
@@ -5,8 +5,9 @@ import { COLOURS, Column, Row, TitleFont } from '../../utils';
 import { SeriesRelationshipMap } from './MoegeChart';
 import { VisualNovelProps } from './visualNovelData';
 import { SequelsPopup } from './SequelsPopup';
-import { IMAGE_WIDTH, ThumbnailImage } from './utils';
-import { GenreFocus, VisualNovelCard } from './VisualNovelCard';
+import { IMAGE_WIDTH, SEQUELS_OFFSET, ThumbnailImage } from './utils';
+import { GenreFocus } from './utils';
+import { VisualNovelCard } from './VisualNovelCard';
 
 export interface ChartEntryProps extends VisualNovelProps {
     allSequelRelationships?: SeriesRelationshipMap;
@@ -113,6 +114,7 @@ export const ChartEntry: React.FC<ChartEntryProps> = ({
                                     alt=""
                                     $outlineColour={outlineColour}
                                     $index={index}
+                                    $cardStackCount={sequels?.length}
                                 />
                             </Row>
                         )
@@ -122,8 +124,6 @@ export const ChartEntry: React.FC<ChartEntryProps> = ({
         </Container>
     );
 };
-
-const SEQUELS_OFFSET = 5;
 
 const Container = styled(Column)`
     max-width: ${IMAGE_WIDTH}px;

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -53,10 +53,7 @@ export const MoegeChart: React.FC<IProps> = ({
     let recommendedVisualNovels: VisualNovelProps[] = [];
 
     const filteredReleasedVisualNovels = visualNovelData.filter(visualNovel => {
-        if (isSelectedShowRecommendedFilter && visualNovel.isRecommended) {
-            recommendedVisualNovels.push(visualNovel);
-            return false;
-        } else if (
+        if (
             selectedPlaytimeFilter !== null &&
             selectedPlaytimeFilter !== visualNovel.playtime
         ) {
@@ -78,38 +75,21 @@ export const MoegeChart: React.FC<IProps> = ({
             (!visualNovel.sequels || visualNovel.sequels.length === 0)
         ) {
             return false;
+        } else if (
+            isSelectedShowRecommendedFilter &&
+            visualNovel.isRecommended
+        ) {
+            recommendedVisualNovels.push(visualNovel);
+            return false;
         } else if (!isSelectedShowSequelFilter && visualNovel.originalGame) {
             if (allSequelRelationships[visualNovel.originalGame]) {
                 allSequelRelationships[visualNovel.originalGame].push({
-                    vndbLink: visualNovel.vndbLink,
-                    thumbnailSource: visualNovel.thumbnailSource,
-                    name: visualNovel.name,
-                    attributes: visualNovel.attributes,
-                    genreFocus: visualNovel.genreFocus,
-                    descriptionFirstRowText:
-                        visualNovel.descriptionFirstRowText,
-                    descriptionSecondRowText:
-                        visualNovel.descriptionSecondRowText,
-                    playtime: visualNovel.playtime,
-                    translationReleaseDate: visualNovel.translationReleaseDate,
-                    isRecommended: visualNovel.isRecommended
+                    ...visualNovel
                 });
             } else {
                 allSequelRelationships[visualNovel.originalGame] = [
                     {
-                        vndbLink: visualNovel.vndbLink,
-                        thumbnailSource: visualNovel.thumbnailSource,
-                        name: visualNovel.name,
-                        attributes: visualNovel.attributes,
-                        genreFocus: visualNovel.genreFocus,
-                        descriptionFirstRowText:
-                            visualNovel.descriptionFirstRowText,
-                        descriptionSecondRowText:
-                            visualNovel.descriptionSecondRowText,
-                        playtime: visualNovel.playtime,
-                        translationReleaseDate:
-                            visualNovel.translationReleaseDate,
-                        isRecommended: visualNovel.isRecommended
+                        ...visualNovel
                     }
                 ];
             }

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -13,34 +13,34 @@ import {
 import { VisualNovelProps, visualNovelData } from './visualNovelData';
 
 import { AnimatePresence } from 'framer-motion';
-import { SortingOption } from '../../SideNav/LegendData';
+import { MiscellaneousSortingOption } from '../../SideNav/LegendData';
 import { MusicNoteIcon } from '../../assets/icons/misc/MusicNoteIcon';
 import { ArrowIcon } from '../../assets/icons/misc/DownArrowIcon';
 import first_cherry_blossom from '../../assets/audio/first-cherry-blossom.mp3';
 import chiisaku_mo_tsuyoki_kokoro from '../../assets/audio/chiisaku-mo-tsuyoki-kokoro.mp3';
 import cute_shining_idol from '../../assets/audio/cute-shining-idol.mp3';
 import { ChartEntry } from './ChartEntry';
-import { GenreFocus, Attribute } from './utils';
+import { GenreFocus, FilterAttribute } from './utils';
 import { PlaytimeLength } from './utils';
 
 export interface SeriesRelationshipMap {
     [originalGameVNDBLink: string]: VisualNovelProps[];
 }
 interface IProps {
-    selectedSortingOptions: SortingOption[];
+    selectedMiscellaneousSortingOptions: MiscellaneousSortingOption[];
     selectedPlaytimeFilter: PlaytimeLength | null;
     selectedGenreFocusFilter: GenreFocus | null;
-    selectedAttributesFilters: Attribute[];
+    selectedFilterAttributes: FilterAttribute[];
     isSelectedHasSequelFilter: boolean;
     isSelectedHideSequelFilter: boolean;
     setIsInPopupView: (value: boolean) => void;
 }
 
 export const MoegeChart: React.FC<IProps> = ({
-    selectedSortingOptions,
+    selectedMiscellaneousSortingOptions,
     selectedPlaytimeFilter,
     selectedGenreFocusFilter,
-    selectedAttributesFilters,
+    selectedFilterAttributes,
     isSelectedHasSequelFilter,
     isSelectedHideSequelFilter,
     setIsInPopupView
@@ -59,8 +59,8 @@ export const MoegeChart: React.FC<IProps> = ({
         ) {
             return false;
         } else if (
-            selectedAttributesFilters.length !== 0 &&
-            selectedAttributesFilters.some(
+            selectedFilterAttributes.length !== 0 &&
+            selectedFilterAttributes.some(
                 attribute => !visualNovel.attributes.includes(attribute)
             )
         ) {
@@ -119,10 +119,10 @@ export const MoegeChart: React.FC<IProps> = ({
 
     let isSortingByChronological = false;
 
-    if (selectedSortingOptions.length !== 0) {
-        selectedSortingOptions.forEach(option => {
+    if (selectedMiscellaneousSortingOptions.length !== 0) {
+        selectedMiscellaneousSortingOptions.forEach(option => {
             switch (option) {
-                case SortingOption.CHRONOLOGICAL:
+                case MiscellaneousSortingOption.CHRONOLOGICAL:
                     filteredReleasedVisualNovels.sort(
                         (visualNovelOne, visualNovelTwo) =>
                             visualNovelTwo.translationReleaseDate! -
@@ -130,7 +130,7 @@ export const MoegeChart: React.FC<IProps> = ({
                     );
                     isSortingByChronological = true;
                     break;
-                case SortingOption.RANDOM: {
+                case MiscellaneousSortingOption.RANDOM: {
                     while (filteredReleasedVisualNovels.length > 10) {
                         filteredReleasedVisualNovels.splice(
                             Math.floor(
@@ -151,10 +151,10 @@ export const MoegeChart: React.FC<IProps> = ({
     let unreleasedVisualNovels: VisualNovelProps[] = [];
 
     if (
-        selectedSortingOptions.length === 0 &&
+        selectedMiscellaneousSortingOptions.length === 0 &&
         selectedPlaytimeFilter === null &&
         selectedGenreFocusFilter === null &&
-        selectedAttributesFilters.length === 0 &&
+        selectedFilterAttributes.length === 0 &&
         isSelectedHasSequelFilter === false
     ) {
         unreleasedVisualNovels = visualNovelData.filter(

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -23,6 +23,7 @@ import cute_shining_idol from '../../assets/audio/cute-shining-idol.mp3';
 import { ChartEntry } from './ChartEntry';
 import { GenreFocus, FilterAttribute } from './utils';
 import { PlaytimeLength } from './utils';
+import Background from '../../assets/thumbnails/Background.jpg';
 
 export interface SeriesRelationshipMap {
     [originalGameVNDBLink: string]: VisualNovelProps[];
@@ -351,6 +352,7 @@ export const MoegeChart: React.FC<IProps> = ({
                     </VerticalFade>
                 ) : null}
             </AnimatePresence>
+            <BackgroundImage src={Background} />
         </Container>
     );
 };
@@ -418,4 +420,11 @@ const InfoBar = styled(Row)`
     & > :last-child {
         margin-left: auto;
     }
+`;
+
+const BackgroundImage = styled.img`
+    position: fixed;
+    z-index: -1000;
+    bottom: 0;
+    right: 0;
 `;

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -261,7 +261,7 @@ export const MoegeChart: React.FC<IProps> = ({
                 {recommendedVisualNovels.length > 0 ? (
                     <VerticalFade>
                         <MainHeader>
-                            remaining translated moege
+                            translated moege
                             <Button
                                 onClick={() =>
                                     upcomingReleasesRef.current?.scrollIntoView(
@@ -324,7 +324,7 @@ export const MoegeChart: React.FC<IProps> = ({
                                 <Row>
                                     <ArrowIcon rotate={180} />
                                     <UpcomingReleasesFont>
-                                        Back to translated releases
+                                        Back to top
                                     </UpcomingReleasesFont>
                                 </Row>
                             </Button>

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -138,6 +138,11 @@ export const MoegeChart: React.FC<IProps> = ({
                             visualNovelTwo.translationReleaseDate! -
                             visualNovelOne.translationReleaseDate!
                     );
+                    recommendedVisualNovels.sort(
+                        (visualNovelOne, visualNovelTwo) =>
+                            visualNovelTwo.translationReleaseDate! -
+                            visualNovelOne.translationReleaseDate!
+                    );
                     isSortingByChronological = true;
                     break;
                 case MiscellaneousSortingOption.RANDOM: {
@@ -146,6 +151,14 @@ export const MoegeChart: React.FC<IProps> = ({
                             Math.floor(
                                 Math.random() *
                                     filteredReleasedVisualNovels.length
+                            ),
+                            1
+                        );
+                    }
+                    while (recommendedVisualNovels.length > 10) {
+                        recommendedVisualNovels.splice(
+                            Math.floor(
+                                Math.random() * recommendedVisualNovels.length
                             ),
                             1
                         );

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -20,7 +20,8 @@ import first_cherry_blossom from '../../assets/audio/first-cherry-blossom.mp3';
 import chiisaku_mo_tsuyoki_kokoro from '../../assets/audio/chiisaku-mo-tsuyoki-kokoro.mp3';
 import cute_shining_idol from '../../assets/audio/cute-shining-idol.mp3';
 import { ChartEntry } from './ChartEntry';
-import { PlaytimeLength, GenreFocus, Attribute } from './VisualNovelCard';
+import { GenreFocus, Attribute } from './utils';
+import { PlaytimeLength } from './utils';
 
 export interface SeriesRelationshipMap {
     [originalGameVNDBLink: string]: VisualNovelProps[];

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -215,11 +215,11 @@ export const MoegeChart: React.FC<IProps> = ({
 
     return (
         <Container>
-            <MainHeader>
+            <MoechartFont>
                 <Row>
                     <VNFont ref={moechartTitleRef}>/vn/</VNFont> MOECHART
                 </Row>
-            </MainHeader>
+            </MoechartFont>
             <InfoBar>
                 <MusicButton
                     onClick={handlePlaySong}
@@ -401,6 +401,11 @@ const MainHeader = styled(HeaderFont)`
 
 const OtherHeader = styled(MainHeader)`
     margin-bottom: 40px;
+`;
+
+const MoechartFont = styled(MainHeader)`
+    font-weight: 800;
+    letter-spacing: 0.07rem;
 `;
 
 const VNFont = styled.div`

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -154,8 +154,7 @@ export const MoegeChart: React.FC<IProps> = ({
         selectedPlaytimeFilter === null &&
         selectedGenreFocusFilter === null &&
         selectedAttributesFilters.length === 0 &&
-        isSelectedHasSequelFilter === false &&
-        isSelectedHideSequelFilter === false
+        isSelectedHasSequelFilter === false
     ) {
         unreleasedVisualNovels = visualNovelData.filter(
             visualNovel => visualNovel.isUpcomingRelease

--- a/src/views/HomePage/Chart/MoegeChart.tsx
+++ b/src/views/HomePage/Chart/MoegeChart.tsx
@@ -83,7 +83,8 @@ export const MoegeChart: React.FC<IProps> = ({
                     descriptionSecondRowText:
                         visualNovel.descriptionSecondRowText,
                     playtime: visualNovel.playtime,
-                    translationReleaseDate: visualNovel.translationReleaseDate
+                    translationReleaseDate: visualNovel.translationReleaseDate,
+                    isRecommended: visualNovel.isRecommended
                 });
             } else {
                 allSequelRelationships[visualNovel.originalGame] = [
@@ -99,7 +100,8 @@ export const MoegeChart: React.FC<IProps> = ({
                             visualNovel.descriptionSecondRowText,
                         playtime: visualNovel.playtime,
                         translationReleaseDate:
-                            visualNovel.translationReleaseDate
+                            visualNovel.translationReleaseDate,
+                        isRecommended: visualNovel.isRecommended
                     }
                 ];
             }

--- a/src/views/HomePage/Chart/Popup.tsx
+++ b/src/views/HomePage/Chart/Popup.tsx
@@ -32,6 +32,7 @@ const Background = styled(Column)`
 
 const Container = styled(Column)`
     margin-left: -${SIDE_NAV_WIDTH}px;
-    width: calc(80% - ${SIDE_NAV_WIDTH}px);
-    height: 80vh;
+    width: calc(90% - ${SIDE_NAV_WIDTH}px);
+    height: 70%;
+    margin-bottom: 15%;
 `;

--- a/src/views/HomePage/Chart/RecommendedPopup.tsx
+++ b/src/views/HomePage/Chart/RecommendedPopup.tsx
@@ -1,37 +1,79 @@
 import styled from 'styled-components';
-import { Column, HeaderFont, Row } from '../../utils';
+import { COLOURS, Column, LabelFont, Row, TitleFont } from '../../utils';
 import { Popup } from './Popup';
+import { ChartEntryProps } from './ChartEntry';
+import { ThumbnailImage } from './utils';
 
-interface IProps {
+interface IProps extends ChartEntryProps {
     isOpen?: boolean;
     onClose?: () => void;
+    outlineColour?: string;
 }
 
-export const RecommendedPopup: React.FC<IProps> = ({ isOpen, onClose }) => {
+export const RecommendedPopup: React.FC<IProps> = ({
+    isOpen,
+    onClose,
+    name,
+    thumbnailSource,
+    sequels,
+    outlineColour,
+    recommendedDescription
+}) => {
     return (
         <Popup isOpen={isOpen} onClose={onClose}>
-            <Column $centered>
-                <EntriesContainer $maxHeight $centered></EntriesContainer>
-                <StyledHeaderFont>Recommended VN Information</StyledHeaderFont>
-            </Column>
+            <ContentContainer $centered $maxWidth $maxHeight>
+                <Row>
+                    <ImageContainer>
+                        <ImageFont>{name}</ImageFont>
+                        <RecommendedImage
+                            src={thumbnailSource}
+                            loading="lazy"
+                            alt=""
+                            $outlineColour={outlineColour}
+                            $cardStackCount={sequels?.length}
+                        />
+                    </ImageContainer>
+                    <DescriptionContainer>
+                        <DescriptionFont>
+                            {recommendedDescription}
+                        </DescriptionFont>
+                    </DescriptionContainer>
+                </Row>
+            </ContentContainer>
         </Popup>
     );
 };
 
-const EntriesContainer = styled(Row)`
-    position: fixed;
-    flex-wrap: wrap;
-    top: 0;
-    gap: 0px 80px;
-    margin-top: 100px;
-    @media (max-width: 1050px) {
-        margin-top: 250px;
-        overflow: auto;
-        height: 75vh;
-    }
+const ContentContainer = styled(Column)`
+    border: 1px solid ${COLOURS.TEXT};
 `;
 
-const StyledHeaderFont = styled(HeaderFont)`
-    position: fixed;
-    top: 5%;
+const RecommendedImage = styled(ThumbnailImage)`
+    height: 550px;
+    width: 380px;
+    pointer-events: none;
+`;
+
+const ImageContainer = styled(Column)`
+    margin-left: 50px;
+    margin-right: auto;
+`;
+
+const ImageFont = styled(TitleFont)`
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    font-size: 2.5rem;
+    font-family: monospace;
+    margin-bottom: 20px;
+`;
+
+const DescriptionContainer = styled.div`
+    margin: 200px 30px 0;
+`;
+
+const DescriptionFont = styled(LabelFont)`
+    font-family: sans-serif;
+    font-size: 3.2rem;
+    text-align: justify;
 `;

--- a/src/views/HomePage/Chart/RecommendedPopup.tsx
+++ b/src/views/HomePage/Chart/RecommendedPopup.tsx
@@ -68,12 +68,11 @@ const ImageFont = styled(TitleFont)`
     margin-bottom: 20px;
 `;
 
-const DescriptionContainer = styled.div`
+const DescriptionContainer = styled(Column)`
     margin: 200px 30px 0;
 `;
 
 const DescriptionFont = styled(LabelFont)`
-    font-family: sans-serif;
-    font-size: 3.2rem;
+    font-size: 2.2rem;
     text-align: justify;
 `;

--- a/src/views/HomePage/Chart/RecommendedPopup.tsx
+++ b/src/views/HomePage/Chart/RecommendedPopup.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+import { Column, HeaderFont, Row } from '../../utils';
+import { Popup } from './Popup';
+
+interface IProps {
+    isOpen?: boolean;
+    onClose?: () => void;
+}
+
+export const RecommendedPopup: React.FC<IProps> = ({ isOpen, onClose }) => {
+    return (
+        <Popup isOpen={isOpen} onClose={onClose}>
+            <Column $centered>
+                <EntriesContainer $maxHeight $centered></EntriesContainer>
+                <StyledHeaderFont>Recommended VN Information</StyledHeaderFont>
+            </Column>
+        </Popup>
+    );
+};
+
+const EntriesContainer = styled(Row)`
+    position: fixed;
+    flex-wrap: wrap;
+    top: 0;
+    gap: 0px 80px;
+    margin-top: 100px;
+    @media (max-width: 1050px) {
+        margin-top: 250px;
+        overflow: auto;
+        height: 75vh;
+    }
+`;
+
+const StyledHeaderFont = styled(HeaderFont)`
+    position: fixed;
+    top: 5%;
+`;

--- a/src/views/HomePage/Chart/SequelsPopup.tsx
+++ b/src/views/HomePage/Chart/SequelsPopup.tsx
@@ -1,8 +1,14 @@
 import styled from 'styled-components';
-import { Column, HeaderFont, Row } from '../../utils';
+import {
+    Column,
+    HeaderFont,
+    Row,
+    StaggeredEntranceFadeSlow
+} from '../../utils';
 import { Popup } from './Popup';
 import { SeriesRelationshipMap } from './MoegeChart';
 import { VisualNovelCard } from './VisualNovelCard';
+import { AnimatePresence } from 'framer-motion';
 
 interface IProps {
     isOpen?: boolean;
@@ -31,31 +37,42 @@ export const SequelsPopup: React.FC<IProps> = ({
         <Popup isOpen={isOpen} onClose={onClose}>
             <Column $centered>
                 <EntriesContainer $maxHeight $centered>
-                    {allSequelRelations[originalGame].map(relationship => {
-                        return (
-                            <VisualNovelCard
-                                name={relationship.name}
-                                vndbLink={relationship.vndbLink}
-                                thumbnailSource={relationship.thumbnailSource}
-                                attributes={relationship.attributes}
-                                genreFocus={relationship.genreFocus}
-                                descriptionFirstRowText={
-                                    relationship.descriptionFirstRowText
-                                }
-                                descriptionSecondRowText={
-                                    relationship.descriptionSecondRowText
-                                }
-                                playtime={relationship.playtime}
-                                translationReleaseDate={
-                                    relationship.translationReleaseDate
-                                }
-                                shouldDisplayDateInTitle={
-                                    shouldDisplayDateInTitle
-                                }
-                                originalGame={originalGame}
-                            />
-                        );
-                    })}
+                    <AnimatePresence>
+                        {allSequelRelations[originalGame].map(
+                            (relationship, index) => {
+                                return (
+                                    <StaggeredEntranceFadeSlow
+                                        key={relationship.vndbLink}
+                                        index={index}
+                                    >
+                                        <VisualNovelCard
+                                            name={relationship.name}
+                                            vndbLink={relationship.vndbLink}
+                                            thumbnailSource={
+                                                relationship.thumbnailSource
+                                            }
+                                            attributes={relationship.attributes}
+                                            genreFocus={relationship.genreFocus}
+                                            descriptionFirstRowText={
+                                                relationship.descriptionFirstRowText
+                                            }
+                                            descriptionSecondRowText={
+                                                relationship.descriptionSecondRowText
+                                            }
+                                            playtime={relationship.playtime}
+                                            translationReleaseDate={
+                                                relationship.translationReleaseDate
+                                            }
+                                            shouldDisplayDateInTitle={
+                                                shouldDisplayDateInTitle
+                                            }
+                                            originalGame={originalGame}
+                                        />
+                                    </StaggeredEntranceFadeSlow>
+                                );
+                            }
+                        )}
+                    </AnimatePresence>
                 </EntriesContainer>
                 <StyledHeaderFont>
                     Translated Fandiscs and Sequels

--- a/src/views/HomePage/Chart/SequelsPopup.tsx
+++ b/src/views/HomePage/Chart/SequelsPopup.tsx
@@ -6,27 +6,24 @@ import {
     StaggeredEntranceFadeSlow
 } from '../../utils';
 import { Popup } from './Popup';
-import { SeriesRelationshipMap } from './MoegeChart';
-import { VisualNovelCard } from './VisualNovelCard';
+import { VisualNovelCard, VisualNovelCardProps } from './VisualNovelCard';
 import { AnimatePresence } from 'framer-motion';
 
 interface IProps {
     isOpen?: boolean;
     onClose?: () => void;
-    originalGame: string;
-    allSequelRelations: SeriesRelationshipMap;
+    sequelRelations: VisualNovelCardProps[];
     shouldDisplayDateInTitle?: boolean;
 }
 
 export const SequelsPopup: React.FC<IProps> = ({
     isOpen,
     onClose,
-    originalGame,
-    allSequelRelations,
+    sequelRelations,
     shouldDisplayDateInTitle
 }) => {
     if (shouldDisplayDateInTitle) {
-        allSequelRelations[originalGame].sort(
+        sequelRelations.sort(
             (visualNovelOne, visualNovelTwo) =>
                 visualNovelTwo.translationReleaseDate! -
                 visualNovelOne.translationReleaseDate!
@@ -38,18 +35,21 @@ export const SequelsPopup: React.FC<IProps> = ({
             <Column $centered>
                 <EntriesContainer $maxHeight $centered>
                     <AnimatePresence>
-                        {allSequelRelations[originalGame].map(
-                            (relationship, index) => {
-                                return (
-                                    <StaggeredEntranceFadeSlow
-                                        key={relationship.vndbLink}
-                                        index={index}
-                                    >
-                                        <VisualNovelCard {...relationship} />
-                                    </StaggeredEntranceFadeSlow>
-                                );
-                            }
-                        )}
+                        {sequelRelations.map((relationship, index) => {
+                            return (
+                                <StaggeredEntranceFadeSlow
+                                    key={relationship.vndbLink}
+                                    index={index}
+                                >
+                                    <VisualNovelCard
+                                        {...relationship}
+                                        shouldDisplayDateInTitle={
+                                            shouldDisplayDateInTitle
+                                        }
+                                    />
+                                </StaggeredEntranceFadeSlow>
+                            );
+                        })}
                     </AnimatePresence>
                 </EntriesContainer>
                 <StyledHeaderFont>

--- a/src/views/HomePage/Chart/SequelsPopup.tsx
+++ b/src/views/HomePage/Chart/SequelsPopup.tsx
@@ -45,29 +45,7 @@ export const SequelsPopup: React.FC<IProps> = ({
                                         key={relationship.vndbLink}
                                         index={index}
                                     >
-                                        <VisualNovelCard
-                                            name={relationship.name}
-                                            vndbLink={relationship.vndbLink}
-                                            thumbnailSource={
-                                                relationship.thumbnailSource
-                                            }
-                                            attributes={relationship.attributes}
-                                            genreFocus={relationship.genreFocus}
-                                            descriptionFirstRowText={
-                                                relationship.descriptionFirstRowText
-                                            }
-                                            descriptionSecondRowText={
-                                                relationship.descriptionSecondRowText
-                                            }
-                                            playtime={relationship.playtime}
-                                            translationReleaseDate={
-                                                relationship.translationReleaseDate
-                                            }
-                                            shouldDisplayDateInTitle={
-                                                shouldDisplayDateInTitle
-                                            }
-                                            originalGame={originalGame}
-                                        />
+                                        <VisualNovelCard {...relationship} />
                                     </StaggeredEntranceFadeSlow>
                                 );
                             }

--- a/src/views/HomePage/Chart/SequelsPopup.tsx
+++ b/src/views/HomePage/Chart/SequelsPopup.tsx
@@ -32,8 +32,11 @@ export const SequelsPopup: React.FC<IProps> = ({
 
     return (
         <Popup isOpen={isOpen} onClose={onClose}>
-            <Column $centered>
-                <EntriesContainer $maxHeight $centered>
+            <Column $maxWidth $maxHeight $centered>
+                <StyledHeaderFont>
+                    Translated Fandiscs and Sequels
+                </StyledHeaderFont>
+                <EntriesContainer $maxWidth $centered>
                     <AnimatePresence>
                         {sequelRelations.map((relationship, index) => {
                             return (
@@ -52,28 +55,16 @@ export const SequelsPopup: React.FC<IProps> = ({
                         })}
                     </AnimatePresence>
                 </EntriesContainer>
-                <StyledHeaderFont>
-                    Translated Fandiscs and Sequels
-                </StyledHeaderFont>
             </Column>
         </Popup>
     );
 };
 
 const EntriesContainer = styled(Row)`
-    position: fixed;
     flex-wrap: wrap;
-    top: 0;
     gap: 0px 80px;
-    margin-top: 100px;
-    @media (max-width: 1050px) {
-        margin-top: 250px;
-        overflow: auto;
-        height: 75vh;
-    }
 `;
 
 const StyledHeaderFont = styled(HeaderFont)`
-    position: fixed;
-    top: 5%;
+    margin-bottom: 100px;
 `;

--- a/src/views/HomePage/Chart/VisualNovelCard.tsx
+++ b/src/views/HomePage/Chart/VisualNovelCard.tsx
@@ -35,9 +35,10 @@ import {
     ThumbnailImage
 } from './utils';
 import { PlaytimeLength } from './utils';
-import { HelpIcon } from '../../assets/icons/misc/HelpIcon';
 import moment from 'moment';
 import { StarIcon } from '../../assets/icons/attribute/StarIcon';
+import { QuestionDiscIcon } from '../../assets/icons/misc/QuestionDiscIcon';
+import { QuestionStarIcon } from '../../assets/icons/misc/QuestionStarIcon';
 
 export interface VisualNovelCardProps extends VisualNovelProps {
     sequelInfoOnClick?: () => void;
@@ -90,12 +91,12 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
             <TopRow>
                 {sequelInfoOnClick && !descriptionInfoOnClick ? (
                     <HelpButton onClick={sequelInfoOnClick}>
-                        <HelpIcon />
+                        <QuestionDiscIcon />
                     </HelpButton>
                 ) : null}
                 {descriptionInfoOnClick ? (
                     <HelpButton onClick={descriptionInfoOnClick}>
-                        <HelpIcon />
+                        <QuestionStarIcon />
                     </HelpButton>
                 ) : null}
                 {shouldDisplayDateInTitle ? (

--- a/src/views/HomePage/Chart/VisualNovelCard.tsx
+++ b/src/views/HomePage/Chart/VisualNovelCard.tsx
@@ -27,7 +27,7 @@ import { ScenarioSelectionIcon } from '../../assets/icons/attribute/ScenarioSele
 import { HasSequelIcon } from '../../assets/icons/attribute/HasSequalIcon';
 import { IsSequelIcon } from '../../assets/icons/attribute/IsSequelIcon';
 import {
-    Attribute,
+    FilterAttribute,
     GenreFocus,
     IMAGE_HEIGHT,
     IMAGE_WIDTH,
@@ -57,7 +57,7 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
     shouldDisplayDateInTitle,
     translationReleaseDate
 }) => {
-    const attributesOrder = Object.values(Attribute);
+    const attributesOrder = Object.values(FilterAttribute);
     let outlineColour = COLOURS.GENRE.NUKIGE;
     switch (genreFocus) {
         case GenreFocus.COMEDY:
@@ -134,47 +134,64 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                                         attributesOrder.indexOf(attributeTwo)
                                 )
                                 .map(attribute => {
-                                    if (attribute === Attribute.ADV_TEXTBOX) {
+                                    if (
+                                        attribute ===
+                                        FilterAttribute.ADV_TEXTBOX
+                                    ) {
                                         return <ADVIcon key="adv" />;
                                     }
-                                    if (attribute === Attribute.NVL_TEXTBOX) {
+                                    if (
+                                        attribute ===
+                                        FilterAttribute.NVL_TEXTBOX
+                                    ) {
                                         return <NVLIcon key="nvl" />;
                                     }
                                     if (
-                                        attribute === Attribute.FLOATING_TEXTBOX
+                                        attribute ===
+                                        FilterAttribute.FLOATING_TEXTBOX
                                     ) {
                                         return <FloatingTextIcon key="float" />;
                                     }
                                     if (
                                         attribute ===
-                                        Attribute.UNLOCKABLE_ROUTES
+                                        FilterAttribute.UNLOCKABLE_ROUTES
                                     ) {
                                         return <LockIcon key="lock" />;
                                     }
                                     if (
-                                        attribute === Attribute.BRANCHING_PLOT
+                                        attribute ===
+                                        FilterAttribute.BRANCHING_PLOT
                                     ) {
                                         return <BranchIcon key="branch" />;
                                     }
                                     if (
-                                        attribute === Attribute.LADDER_STRUCTURE
+                                        attribute ===
+                                        FilterAttribute.LADDER_STRUCTURE
                                     ) {
                                         return <LadderIcon key="ladder" />;
                                     }
-                                    if (attribute === Attribute.TRUE_ROUTE) {
+                                    if (
+                                        attribute === FilterAttribute.TRUE_ROUTE
+                                    ) {
                                         return <TrueIcon key="true" />;
                                     }
-                                    if (attribute === Attribute.LINEAR_PLOT) {
+                                    if (
+                                        attribute ===
+                                        FilterAttribute.LINEAR_PLOT
+                                    ) {
                                         return <LinearPlotIcon key="linear" />;
                                     }
-                                    if (attribute === Attribute.KINETIC_NOVEL) {
+                                    if (
+                                        attribute ===
+                                        FilterAttribute.KINETIC_NOVEL
+                                    ) {
                                         return (
                                             <KineticNovelIcon key="kinetic" />
                                         );
                                     }
                                     if (
                                         attribute ===
-                                        Attribute.SCENARIO_SELECTION
+                                        FilterAttribute.SCENARIO_SELECTION
                                     ) {
                                         return (
                                             <ScenarioSelectionIcon key="scenario" />
@@ -182,7 +199,7 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                                     }
                                     if (
                                         attribute ===
-                                        Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+                                        FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
                                     ) {
                                         return (
                                             <FrenchGirlIcon key="frenchgirl" />

--- a/src/views/HomePage/Chart/VisualNovelCard.tsx
+++ b/src/views/HomePage/Chart/VisualNovelCard.tsx
@@ -31,11 +31,13 @@ import {
     GenreFocus,
     IMAGE_HEIGHT,
     IMAGE_WIDTH,
+    SEQUELS_OFFSET,
     ThumbnailImage
 } from './utils';
 import { PlaytimeLength } from './utils';
 import { HelpIcon } from '../../assets/icons/misc/HelpIcon';
 import moment from 'moment';
+import { StarIcon } from '../../assets/icons/attribute/StarIcon';
 
 export interface VisualNovelCardProps extends VisualNovelProps {
     moreInfoOnClick?: () => void;
@@ -55,7 +57,8 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
     originalGame,
     moreInfoOnClick,
     shouldDisplayDateInTitle,
-    translationReleaseDate
+    translationReleaseDate,
+    isRecommended
 }) => {
     const attributesOrder = Object.values(FilterAttribute);
     let outlineColour = COLOURS.GENRE.NUKIGE;
@@ -106,9 +109,13 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                         alt=""
                         $outlineColour={outlineColour}
                         $cardStackCount={sequels?.length}
+                        $shouldScaleSize={!!moreInfoOnClick}
                     />
                 </Link>
-                <IconsContainer>
+                <IconsContainer
+                    $cardStackCount={sequels?.length}
+                    $shouldScaleMarginLeft={!!moreInfoOnClick}
+                >
                     <PlaytimeIconContainer $outlineColour={outlineColour}>
                         {playtime === PlaytimeLength.SHORT ? (
                             <PlaytimeShortIcon />
@@ -127,6 +134,7 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                         <AdditionalIconsContainer
                             $outlineColour={outlineColour}
                         >
+                            {isRecommended ? <StarIcon /> : null}
                             {attributes
                                 .sort(
                                     (attributeOne, attributeTwo) =>
@@ -208,11 +216,9 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                                     return <></>;
                                 })}
                             {sequels?.length && sequels.length > 0 ? (
-                                <HasSequelIcon key="has-sequel" />
+                                <HasSequelIcon />
                             ) : null}
-                            {originalGame ? (
-                                <IsSequelIcon key="has-sequel" />
-                            ) : null}
+                            {originalGame ? <IsSequelIcon /> : null}
                         </AdditionalIconsContainer>
                     </AdditionalIconsContainerWrapper>
                 </IconsContainer>
@@ -240,8 +246,10 @@ const ContentBody = styled(Row)`
     height: ${IMAGE_HEIGHT}px;
 `;
 
-const IconsContainer = styled(Column)`
-    margin-left: 10px;
+const IconsContainer = styled(Column)<{
+    $cardStackCount?: number;
+    $shouldScaleMarginLeft?: boolean;
+}>`
     padding: 5px;
     display: flex;
     height: 100%;
@@ -249,6 +257,15 @@ const IconsContainer = styled(Column)`
         align-self: flex-end;
         justify-content: flex-end;
     }
+
+    ${({ $cardStackCount, $shouldScaleMarginLeft }) =>
+        $cardStackCount && $shouldScaleMarginLeft
+            ? css`
+                  margin-left: ${$cardStackCount * SEQUELS_OFFSET + 10}px;
+              `
+            : css`
+                  margin-left: 10px;
+              `}
 `;
 
 const PlaytimeIconContainer = styled.div<{ $outlineColour: string }>`

--- a/src/views/HomePage/Chart/VisualNovelCard.tsx
+++ b/src/views/HomePage/Chart/VisualNovelCard.tsx
@@ -26,39 +26,16 @@ import { VisualNovelProps } from './visualNovelData';
 import { ScenarioSelectionIcon } from '../../assets/icons/attribute/ScenarioSelectionIcon';
 import { HasSequelIcon } from '../../assets/icons/attribute/HasSequalIcon';
 import { IsSequelIcon } from '../../assets/icons/attribute/IsSequelIcon';
-import { IMAGE_HEIGHT, IMAGE_WIDTH, ThumbnailImage } from './utils';
+import {
+    Attribute,
+    GenreFocus,
+    IMAGE_HEIGHT,
+    IMAGE_WIDTH,
+    ThumbnailImage
+} from './utils';
+import { PlaytimeLength } from './utils';
 import { HelpIcon } from '../../assets/icons/misc/HelpIcon';
 import moment from 'moment';
-
-export enum PlaytimeLength {
-    SHORT = 'SHORT',
-    MEDIUM = 'MEDIUM',
-    LONG = 'LONG',
-    VERY_LONG = 'VERY_LONG'
-}
-
-export enum Attribute {
-    ADV_TEXTBOX = 'ADV_TEXTBOX',
-    NVL_TEXTBOX = 'NVL_TEXTBOX',
-    FLOATING_TEXTBOX = 'FLOATING_TEXTBOX',
-    UNLOCKABLE_ROUTES = 'UNLOCKABLE_ROUTES',
-    BRANCHING_PLOT = 'BRANCHING_PLOT',
-    LADDER_STRUCTURE = 'LADDER_STRUCTURE',
-    TRUE_ROUTE = 'TRUE_ROUTE',
-    LINEAR_PLOT = 'LINEAR_PLOT',
-    KINETIC_NOVEL = 'KINETIC_NOVEL',
-    SCENARIO_SELECTION = 'SCENARIO_SELECTION',
-    SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS = 'SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS'
-}
-
-export enum GenreFocus {
-    STORYLINE = 'STORYLINE',
-    STORY_ROMANCE = 'STORY_ROMANCE',
-    ROMANCE = 'ROMANCE',
-    ROM_COM = 'ROM_COM',
-    COMEDY = 'COMEDY',
-    NUKIGE = 'NUKIGE'
-}
 
 export interface VisualNovelCardProps extends VisualNovelProps {
     moreInfoOnClick?: () => void;
@@ -128,10 +105,11 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                         loading="lazy"
                         alt=""
                         $outlineColour={outlineColour}
+                        $cardStackCount={sequels?.length}
                     />
                 </Link>
-                <IconsContainer $outlineColour={outlineColour}>
-                    <PlaytimeIconContainer>
+                <IconsContainer>
+                    <PlaytimeIconContainer $outlineColour={outlineColour}>
                         {playtime === PlaytimeLength.SHORT ? (
                             <PlaytimeShortIcon />
                         ) : null}
@@ -145,63 +123,81 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                             <PlaytimeVeryLongIcon />
                         ) : null}
                     </PlaytimeIconContainer>
-                    <AdditionalIconsContainer>
-                        {attributes
-                            .sort(
-                                (attributeOne, attributeTwo) =>
-                                    attributesOrder.indexOf(attributeOne) -
-                                    attributesOrder.indexOf(attributeTwo)
-                            )
-                            .map(attribute => {
-                                if (attribute === Attribute.ADV_TEXTBOX) {
-                                    return <ADVIcon key="adv" />;
-                                }
-                                if (attribute === Attribute.NVL_TEXTBOX) {
-                                    return <NVLIcon key="nvl" />;
-                                }
-                                if (attribute === Attribute.FLOATING_TEXTBOX) {
-                                    return <FloatingTextIcon key="float" />;
-                                }
-                                if (attribute === Attribute.UNLOCKABLE_ROUTES) {
-                                    return <LockIcon key="lock" />;
-                                }
-                                if (attribute === Attribute.BRANCHING_PLOT) {
-                                    return <BranchIcon key="branch" />;
-                                }
-                                if (attribute === Attribute.LADDER_STRUCTURE) {
-                                    return <LadderIcon key="ladder" />;
-                                }
-                                if (attribute === Attribute.TRUE_ROUTE) {
-                                    return <TrueIcon key="true" />;
-                                }
-                                if (attribute === Attribute.LINEAR_PLOT) {
-                                    return <LinearPlotIcon key="linear" />;
-                                }
-                                if (attribute === Attribute.KINETIC_NOVEL) {
-                                    return <KineticNovelIcon key="kinetic" />;
-                                }
-                                if (
-                                    attribute === Attribute.SCENARIO_SELECTION
-                                ) {
-                                    return (
-                                        <ScenarioSelectionIcon key="scenario" />
-                                    );
-                                }
-                                if (
-                                    attribute ===
-                                    Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
-                                ) {
-                                    return <FrenchGirlIcon key="frenchgirl" />;
-                                }
-                                return <></>;
-                            })}
-                        {sequels?.length && sequels.length > 0 ? (
-                            <HasSequelIcon key="has-sequel" />
-                        ) : null}
-                        {originalGame ? (
-                            <IsSequelIcon key="has-sequel" />
-                        ) : null}
-                    </AdditionalIconsContainer>
+                    <AdditionalIconsContainerWrapper>
+                        <AdditionalIconsContainer
+                            $outlineColour={outlineColour}
+                        >
+                            {attributes
+                                .sort(
+                                    (attributeOne, attributeTwo) =>
+                                        attributesOrder.indexOf(attributeOne) -
+                                        attributesOrder.indexOf(attributeTwo)
+                                )
+                                .map(attribute => {
+                                    if (attribute === Attribute.ADV_TEXTBOX) {
+                                        return <ADVIcon key="adv" />;
+                                    }
+                                    if (attribute === Attribute.NVL_TEXTBOX) {
+                                        return <NVLIcon key="nvl" />;
+                                    }
+                                    if (
+                                        attribute === Attribute.FLOATING_TEXTBOX
+                                    ) {
+                                        return <FloatingTextIcon key="float" />;
+                                    }
+                                    if (
+                                        attribute ===
+                                        Attribute.UNLOCKABLE_ROUTES
+                                    ) {
+                                        return <LockIcon key="lock" />;
+                                    }
+                                    if (
+                                        attribute === Attribute.BRANCHING_PLOT
+                                    ) {
+                                        return <BranchIcon key="branch" />;
+                                    }
+                                    if (
+                                        attribute === Attribute.LADDER_STRUCTURE
+                                    ) {
+                                        return <LadderIcon key="ladder" />;
+                                    }
+                                    if (attribute === Attribute.TRUE_ROUTE) {
+                                        return <TrueIcon key="true" />;
+                                    }
+                                    if (attribute === Attribute.LINEAR_PLOT) {
+                                        return <LinearPlotIcon key="linear" />;
+                                    }
+                                    if (attribute === Attribute.KINETIC_NOVEL) {
+                                        return (
+                                            <KineticNovelIcon key="kinetic" />
+                                        );
+                                    }
+                                    if (
+                                        attribute ===
+                                        Attribute.SCENARIO_SELECTION
+                                    ) {
+                                        return (
+                                            <ScenarioSelectionIcon key="scenario" />
+                                        );
+                                    }
+                                    if (
+                                        attribute ===
+                                        Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+                                    ) {
+                                        return (
+                                            <FrenchGirlIcon key="frenchgirl" />
+                                        );
+                                    }
+                                    return <></>;
+                                })}
+                            {sequels?.length && sequels.length > 0 ? (
+                                <HasSequelIcon key="has-sequel" />
+                            ) : null}
+                            {originalGame ? (
+                                <IsSequelIcon key="has-sequel" />
+                            ) : null}
+                        </AdditionalIconsContainer>
+                    </AdditionalIconsContainerWrapper>
                 </IconsContainer>
             </ContentBody>
             <DescriptionFont $outlineColour={outlineColour} $textAlign="right">
@@ -227,7 +223,7 @@ const ContentBody = styled(Row)`
     height: ${IMAGE_HEIGHT}px;
 `;
 
-const IconsContainer = styled(Column)<{ $outlineColour: string }>`
+const IconsContainer = styled(Column)`
     margin-left: 10px;
     padding: 5px;
     display: flex;
@@ -236,18 +232,32 @@ const IconsContainer = styled(Column)<{ $outlineColour: string }>`
         align-self: flex-end;
         justify-content: flex-end;
     }
+`;
+
+const PlaytimeIconContainer = styled.div<{ $outlineColour: string }>`
+    height: auto;
     ${({ $outlineColour }) =>
         $outlineColour
             ? css`
-                  background-color: ${$outlineColour}88;
+                  background-color: ${$outlineColour}bb;
                   border-radius: 15px;
+                  padding: 5px;
               `
             : ''}
 `;
 
-const PlaytimeIconContainer = styled.div``;
+const AdditionalIconsContainer = styled(Column)<{ $outlineColour: string }>`
+    ${({ $outlineColour }) =>
+        $outlineColour
+            ? css`
+                  background-color: ${$outlineColour}bb;
+                  border-radius: 15px;
+                  padding: 5px;
+              `
+            : ''}
+`;
 
-const AdditionalIconsContainer = styled(Column)`
+const AdditionalIconsContainerWrapper = styled(Column)`
     height: 100%;
 `;
 
@@ -259,9 +269,7 @@ const DescriptionFont = styled(LabelFont)`
     font-size: 0.8rem;
 `;
 
-const HelpButton = styled(Button)`
-    margin-top: -2px;
-`;
+const HelpButton = styled(Button)``;
 
 const TopRow = styled(Row)`
     padding-bottom: 14px;

--- a/src/views/HomePage/Chart/VisualNovelCard.tsx
+++ b/src/views/HomePage/Chart/VisualNovelCard.tsx
@@ -40,8 +40,9 @@ import moment from 'moment';
 import { StarIcon } from '../../assets/icons/attribute/StarIcon';
 
 export interface VisualNovelCardProps extends VisualNovelProps {
-    moreInfoOnClick?: () => void;
+    sequelInfoOnClick?: () => void;
     shouldDisplayDateInTitle?: boolean;
+    descriptionInfoOnClick?: () => void;
 }
 
 export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
@@ -55,10 +56,12 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
     descriptionSecondRowText,
     sequels,
     originalGame,
-    moreInfoOnClick,
+    sequelInfoOnClick,
     shouldDisplayDateInTitle,
     translationReleaseDate,
-    isRecommended
+    isRecommended,
+    descriptionInfoOnClick,
+    isUpcomingRelease
 }) => {
     const attributesOrder = Object.values(FilterAttribute);
     let outlineColour = COLOURS.GENRE.NUKIGE;
@@ -85,8 +88,13 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
     return (
         <Container>
             <TopRow>
-                {moreInfoOnClick ? (
-                    <HelpButton onClick={moreInfoOnClick}>
+                {sequelInfoOnClick && !descriptionInfoOnClick ? (
+                    <HelpButton onClick={sequelInfoOnClick}>
+                        <HelpIcon />
+                    </HelpButton>
+                ) : null}
+                {descriptionInfoOnClick ? (
+                    <HelpButton onClick={descriptionInfoOnClick}>
                         <HelpIcon />
                     </HelpButton>
                 ) : null}
@@ -109,14 +117,17 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                         alt=""
                         $outlineColour={outlineColour}
                         $cardStackCount={sequels?.length}
-                        $shouldScaleSize={!!moreInfoOnClick}
+                        $shouldScaleSize={!!sequelInfoOnClick}
                     />
                 </Link>
                 <IconsContainer
                     $cardStackCount={sequels?.length}
-                    $shouldScaleMarginLeft={!!moreInfoOnClick}
+                    $shouldScaleMarginLeft={!!sequelInfoOnClick}
                 >
-                    <PlaytimeIconContainer $outlineColour={outlineColour}>
+                    <PlaytimeIconContainer
+                        $outlineColour={outlineColour}
+                        $shouldHaveBackgroundColour={!isUpcomingRelease}
+                    >
                         {playtime === PlaytimeLength.SHORT ? (
                             <PlaytimeShortIcon />
                         ) : null}
@@ -133,6 +144,7 @@ export const VisualNovelCard: React.FC<VisualNovelCardProps> = ({
                     <AdditionalIconsContainerWrapper>
                         <AdditionalIconsContainer
                             $outlineColour={outlineColour}
+                            $shouldHaveBackgroundColour={!isUpcomingRelease}
                         >
                             {isRecommended ? <StarIcon /> : null}
                             {attributes
@@ -268,10 +280,13 @@ const IconsContainer = styled(Column)<{
               `}
 `;
 
-const PlaytimeIconContainer = styled.div<{ $outlineColour: string }>`
+const PlaytimeIconContainer = styled.div<{
+    $outlineColour: string;
+    $shouldHaveBackgroundColour: boolean;
+}>`
     height: auto;
-    ${({ $outlineColour }) =>
-        $outlineColour
+    ${({ $outlineColour, $shouldHaveBackgroundColour }) =>
+        $outlineColour && $shouldHaveBackgroundColour
             ? css`
                   background-color: ${$outlineColour}bb;
                   border-radius: 15px;
@@ -280,9 +295,12 @@ const PlaytimeIconContainer = styled.div<{ $outlineColour: string }>`
             : ''}
 `;
 
-const AdditionalIconsContainer = styled(Column)<{ $outlineColour: string }>`
-    ${({ $outlineColour }) =>
-        $outlineColour
+const AdditionalIconsContainer = styled(Column)<{
+    $outlineColour: string;
+    $shouldHaveBackgroundColour: boolean;
+}>`
+    ${({ $outlineColour, $shouldHaveBackgroundColour }) =>
+        $outlineColour && $shouldHaveBackgroundColour
             ? css`
                   background-color: ${$outlineColour}bb;
                   border-radius: 15px;

--- a/src/views/HomePage/Chart/utils.ts
+++ b/src/views/HomePage/Chart/utils.ts
@@ -2,10 +2,53 @@ import styled, { css } from 'styled-components';
 
 export const IMAGE_HEIGHT = 260;
 export const IMAGE_WIDTH = 190;
+export const SEQUELS_OFFSET = 5;
 
-export const ThumbnailImage = styled.img<{ $outlineColour?: string }>`
-    width: ${IMAGE_WIDTH}px;
-    height: ${IMAGE_HEIGHT}px;
+export enum PlaytimeLength {
+    SHORT = 'SHORT',
+    MEDIUM = 'MEDIUM',
+    LONG = 'LONG',
+    VERY_LONG = 'VERY_LONG'
+}
+
+export enum Attribute {
+    ADV_TEXTBOX = 'ADV_TEXTBOX',
+    NVL_TEXTBOX = 'NVL_TEXTBOX',
+    FLOATING_TEXTBOX = 'FLOATING_TEXTBOX',
+    UNLOCKABLE_ROUTES = 'UNLOCKABLE_ROUTES',
+    BRANCHING_PLOT = 'BRANCHING_PLOT',
+    LADDER_STRUCTURE = 'LADDER_STRUCTURE',
+    TRUE_ROUTE = 'TRUE_ROUTE',
+    LINEAR_PLOT = 'LINEAR_PLOT',
+    KINETIC_NOVEL = 'KINETIC_NOVEL',
+    SCENARIO_SELECTION = 'SCENARIO_SELECTION',
+    SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS = 'SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS'
+}
+
+export enum GenreFocus {
+    STORYLINE = 'STORYLINE',
+    STORY_ROMANCE = 'STORY_ROMANCE',
+    ROMANCE = 'ROMANCE',
+    ROM_COM = 'ROM_COM',
+    COMEDY = 'COMEDY',
+    NUKIGE = 'NUKIGE'
+}
+
+export const ThumbnailImage = styled.img<{
+    $outlineColour?: string;
+    $cardStackCount?: number;
+}>`
+    ${({ $cardStackCount }) =>
+        $cardStackCount
+            ? css`
+                  width: ${IMAGE_WIDTH - $cardStackCount * SEQUELS_OFFSET}px;
+                  height: ${IMAGE_HEIGHT - $cardStackCount * SEQUELS_OFFSET}px;
+              `
+            : css`
+                  width: ${IMAGE_WIDTH}px;
+                  height: ${IMAGE_HEIGHT}px;
+              `}
+
     object-fit: cover;
     box-sizing: border-box;
     border-radius: 9px;

--- a/src/views/HomePage/Chart/utils.ts
+++ b/src/views/HomePage/Chart/utils.ts
@@ -11,7 +11,7 @@ export enum PlaytimeLength {
     VERY_LONG = 'VERY_LONG'
 }
 
-export enum Attribute {
+export enum FilterAttribute {
     ADV_TEXTBOX = 'ADV_TEXTBOX',
     NVL_TEXTBOX = 'NVL_TEXTBOX',
     FLOATING_TEXTBOX = 'FLOATING_TEXTBOX',

--- a/src/views/HomePage/Chart/utils.ts
+++ b/src/views/HomePage/Chart/utils.ts
@@ -37,9 +37,10 @@ export enum GenreFocus {
 export const ThumbnailImage = styled.img<{
     $outlineColour?: string;
     $cardStackCount?: number;
+    $shouldScaleSize?: boolean;
 }>`
-    ${({ $cardStackCount }) =>
-        $cardStackCount
+    ${({ $cardStackCount, $shouldScaleSize }) =>
+        $cardStackCount && $shouldScaleSize
             ? css`
                   width: ${IMAGE_WIDTH - $cardStackCount * SEQUELS_OFFSET}px;
                   height: ${IMAGE_HEIGHT - $cardStackCount * SEQUELS_OFFSET}px;

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -357,8 +357,8 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v3537',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: kotori_love_exp,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
-        originalGame: 'https://vndb.org/v264', //TODO scenario selection/anthology
+        attributes: [Attribute.ADV_TEXTBOX, Attribute.SCENARIO_SELECTION],
+        originalGame: 'https://vndb.org/v264',
         genreFocus: GenreFocus.STORYLINE, //TODO Romance?
         descriptionFirstRowText: 'Slice of Life, Wife Heroine',
         descriptionSecondRowText: 'Fantasy',
@@ -502,7 +502,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: nine_shinshou,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT, //TODO scenario selection?
+            Attribute.SCENARIO_SELECTION,
             Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v19829',
@@ -519,7 +519,7 @@ export const visualNovelData: VisualNovelProps[] = [
         attributes: [
             Attribute.ADV_TEXTBOX,
             Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            Attribute.SCENARIO_SELECTION
         ],
         sequels: ['https://vndb.org/v24717'],
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -535,7 +535,7 @@ export const visualNovelData: VisualNovelProps[] = [
         attributes: [
             Attribute.ADV_TEXTBOX,
             Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v21852',
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -567,7 +567,7 @@ export const visualNovelData: VisualNovelProps[] = [
         attributes: [
             Attribute.ADV_TEXTBOX,
             Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1474',
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -643,7 +643,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: miazora_fd,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT, //TODO scenario selection
+            Attribute.SCENARIO_SELECTION,
             Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v16560',
@@ -750,7 +750,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: princess_evangile_wh,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v6710',
         genreFocus: GenreFocus.ROMANCE,
@@ -1296,7 +1296,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: neko_nin_2_plus,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
@@ -1357,7 +1357,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: fureraba_fd,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v11856',
         genreFocus: GenreFocus.ROM_COM,
@@ -1384,7 +1384,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: making_lovers_after,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v21552',
         genreFocus: GenreFocus.ROM_COM,
@@ -1787,7 +1787,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: majikoi_a1,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1802,7 +1802,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: majikoi_a2,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1817,7 +1817,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: majikoi_a3,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1832,7 +1832,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: majikoi_a4,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1947,7 +1947,7 @@ export const visualNovelData: VisualNovelProps[] = [
         thumbnailSource: drapri_plus,
         attributes: [
             Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v28634',
         genreFocus: GenreFocus.COMEDY,
@@ -2079,7 +2079,7 @@ export const visualNovelData: VisualNovelProps[] = [
         attributes: [
             Attribute.ADV_TEXTBOX,
             Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT //TODO scenario selection
+            Attribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v17515',
         genreFocus: GenreFocus.NUKIGE,

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -229,8 +229,7 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORYLINE, //TODO Romance?
         descriptionFirstRowText: 'Group of Friends, Pure Love',
         descriptionSecondRowText: 'Single Heroine',
-        translationReleaseDate: Date.parse('2020-11-06'),
-        isRecommended: true
+        translationReleaseDate: Date.parse('2020-11-06')
     },
     {
         name: 'Aokana EXTRA2',

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -183,7 +183,7 @@ import nekopara_after from '../../assets/thumbnails/nekopara_after.jpg';
 import kemonomichi_love_plus from '../../assets/thumbnails/kemonomichi_love_plus.jpg';
 import kemonomichi_2 from '../../assets/thumbnails/kemonomichi_2.jpg';
 import konosora_snow from '../../assets/thumbnails/konosora_snow.jpg';
-import { Attribute, GenreFocus } from './utils';
+import { FilterAttribute, GenreFocus } from './utils';
 import { PlaytimeLength } from './utils';
 
 export interface VisualNovelProps {
@@ -191,7 +191,7 @@ export interface VisualNovelProps {
     vndbLink: string;
     playtime?: PlaytimeLength;
     thumbnailSource: string;
-    attributes: Attribute[];
+    attributes: FilterAttribute[];
     sequels?: string[];
     originalGame?: string;
     genreFocus: GenreFocus;
@@ -207,7 +207,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v12849',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: aokana,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v20228', 'https://vndb.org/v21438'],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Group of Friends, Sports',
@@ -219,7 +222,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20228',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: aokana_extra1,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v12849',
         genreFocus: GenreFocus.STORYLINE, //TODO Romance?
         descriptionFirstRowText: 'Group of Friends, Pure Love',
@@ -231,7 +234,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21438',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: aokana_extra2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v12849',
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Group of Friends, Sports',
@@ -244,9 +247,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: haretaka,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Student Club, Rockets',
@@ -259,9 +262,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: konosora,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         sequels: ['https://vndb.org/v10979'],
         genreFocus: GenreFocus.STORYLINE,
@@ -275,10 +278,10 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: konosora_fd,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v9093',
         genreFocus: GenreFocus.STORYLINE,
@@ -292,9 +295,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: chrono_clock,
         attributes: [
-            Attribute.FLOATING_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.FLOATING_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Slice of Life Comedy, Deities',
@@ -307,9 +310,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: maitetsu,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Countryside, Trains',
@@ -322,9 +325,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: da_capo,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         sequels: [
             'https://vndb.org/v1708',
@@ -343,9 +346,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: dcif,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         originalGame: 'https://vndb.org/v264', //TODO actually an alternative version
         genreFocus: GenreFocus.STORYLINE,
@@ -358,7 +361,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v3537',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: kotori_love_exp,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.SCENARIO_SELECTION],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
+        ],
         originalGame: 'https://vndb.org/v264',
         genreFocus: GenreFocus.STORYLINE, //TODO Romance?
         descriptionFirstRowText: 'Slice of Life, Wife Heroine',
@@ -371,9 +377,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: da_capo2,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         originalGame: 'https://vndb.org/v264',
         genreFocus: GenreFocus.STORYLINE,
@@ -387,9 +393,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: da_capo3,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         originalGame: 'https://vndb.org/v264',
         genreFocus: GenreFocus.STORYLINE,
@@ -403,10 +409,10 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: yoakena,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Science Fiction, Drama',
@@ -419,9 +425,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: dal_segno,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Slice of Life, Drama',
@@ -434,9 +440,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: hello_good_bye,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Politics, Slice of Life',
@@ -448,7 +454,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v19829',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nine_ep1,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: [
             'https://vndb.org/v21668',
             'https://vndb.org/v23740',
@@ -465,7 +471,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21668',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: nine_ep2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v19829',
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Superpowers, Suspense',
@@ -477,7 +483,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v23740',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: nine_ep3,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v19829',
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Superpowers, Suspense',
@@ -489,7 +495,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26523',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: nine_ep4,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v19829',
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Superpowers, Suspense',
@@ -502,9 +508,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nine_shinshou,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v19829',
         genreFocus: GenreFocus.STORYLINE,
@@ -518,9 +524,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: kinkoi,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         sequels: ['https://vndb.org/v24717'],
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -534,9 +540,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: kinkoi_gt,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v21852',
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -550,9 +556,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.VERY_LONG,
         thumbnailSource: hoshimemo,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE
         ],
         sequels: ['https://vndb.org/v2959'],
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -566,9 +572,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: hoshimemo_eh,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1474',
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -582,9 +588,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: daitoshokan,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Urban Fantasy, Mystery',
@@ -597,9 +603,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: tamayura_mirai,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Fantasy, Mythology',
@@ -612,9 +618,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: sakusaku,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Shinigami, Slice of Life',
@@ -627,9 +633,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: miazora,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         sequels: ['https://vndb.org/v18907'],
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -643,9 +649,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: miazora_fd,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v16560',
         genreFocus: GenreFocus.STORY_ROMANCE,
@@ -659,9 +665,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: koichoco,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Friendship, Student Club',
@@ -673,7 +679,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v10608',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: koiken_otome,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Group of Friends, Action',
         descriptionSecondRowText: 'Superpowers',
@@ -684,7 +693,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v19125',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: corona_blossom,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Slice of Life Comedy, Space',
         descriptionSecondRowText: 'Science Fiction',
@@ -695,7 +707,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17827',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: hitotsuba,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Dousei, Warplanes',
         descriptionSecondRowText: 'Competition',
@@ -707,10 +722,10 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: date_a_live,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.TRUE_ROUTE,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.TRUE_ROUTE,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Dating Sim, Slice of Life',
@@ -723,9 +738,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: sanoba_witch,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Occult Club, Witches',
@@ -737,7 +752,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v6710',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: princess_evangile,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v8900'],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'School Dormitory, Drama',
@@ -750,8 +768,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: princess_evangile_wh,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v6710',
         genreFocus: GenreFocus.ROMANCE,
@@ -765,9 +783,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: koirizo,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Dousei, Slice of Life Comedy',
@@ -779,7 +797,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v9124',
         playtime: PlaytimeLength.VERY_LONG,
         thumbnailSource: hatsukoi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Student Club, Slice of Life',
         descriptionSecondRowText: 'High School',
@@ -791,9 +812,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: cafe_stella,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Cafe, Slice of Life',
@@ -806,9 +827,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: senren_banka,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Rural Japan, Slice of Life',
@@ -821,9 +842,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: riddle_joker,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Secret Identity, Slice of Life',
@@ -835,7 +856,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v898',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: hinatabokko,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Slice of Life, Cafe',
         descriptionSecondRowText: 'University',
@@ -846,7 +870,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v174',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: canvas_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Teacher MC, High School',
         descriptionSecondRowText: 'Painting Club',
@@ -857,7 +884,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v573',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: period,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Angels, High School',
         descriptionSecondRowText: 'Drama',
@@ -868,7 +898,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21903',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: koi_ama,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v24626'],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Cafe, Waitresses',
@@ -880,7 +913,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v24626',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: koi_ama_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         originalGame: 'https://vndb.org/v21903',
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Cafe, Waitresses',
@@ -893,9 +929,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.VERY_LONG,
         thumbnailSource: to_heart_2,
         attributes: [
-            Attribute.NVL_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.NVL_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'High School, Drama',
@@ -907,7 +943,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v23067',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: loca_love,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: ['https://vndb.org/v25690', 'https://vndb.org/v26376'],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Dousei, Destiny',
@@ -919,7 +955,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v25690',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: loca_love_densha,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v23067',
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Dousei, Destiny',
@@ -931,7 +967,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26376',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: loca_love_jinja,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v23067',
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Dousei, Destiny',
@@ -944,9 +980,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: suki_suki,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'School Life Comedy, Fairies',
@@ -958,7 +994,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v14265',
         playtime: PlaytimeLength.VERY_LONG,
         thumbnailSource: hoshi_ori,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Slice of Life, Festival',
         descriptionSecondRowText: 'Passage of Time',
@@ -970,9 +1009,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: yotsunoha,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Slice of Life, Reunion',
@@ -984,7 +1023,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v5942',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: kimihime,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Secret Identity, Slice of Life',
         descriptionSecondRowText: 'School Life Comedy',
@@ -995,7 +1037,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26581',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: amairo_choco,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Cafe, Slice of Life',
         descriptionSecondRowText: 'Kemonomimi',
@@ -1007,9 +1052,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: island_diary,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.LINEAR_PLOT,
-            Attribute.KINETIC_NOVEL
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.LINEAR_PLOT,
+            FilterAttribute.KINETIC_NOVEL
         ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Survival, Slice of Life',
@@ -1021,7 +1066,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22075',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: harmoney,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Wife Heroine, Slice of Life',
         descriptionSecondRowText: 'Single Heroine',
@@ -1032,7 +1077,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v24689',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: study_steady,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v30793'],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Winter, Long H-scenes',
@@ -1044,7 +1092,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v30793',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: icha_x2_study,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v24689',
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Winter, Long H-scenes',
@@ -1056,7 +1107,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v30118',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: himukai,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Pillow Talk, Reunion',
         descriptionSecondRowText: 'Single Heroine',
@@ -1067,7 +1118,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v24586',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: knot_fiction,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Wife Heroine, Adult MC',
         descriptionSecondRowText: 'Single Heroine',
@@ -1078,7 +1129,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20148',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: ninki_seiyuu,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Seiyuu Heroine, Dousei',
         descriptionSecondRowText: 'Drama',
@@ -1089,7 +1143,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v14269',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: love_sweets,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Waitress Heroine, Cafe',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1100,7 +1157,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20232',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: aikagi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Winter, Dousei',
         descriptionSecondRowText: 'Single Heroine',
@@ -1111,7 +1171,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v27367',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: icing,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Bakery, Wife Heroine',
         descriptionSecondRowText: 'Single Heroine',
@@ -1122,7 +1182,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v28',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: shuffle,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v202'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Gods and Devils, Reunion',
@@ -1134,7 +1197,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v202',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: really_really,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v28',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Gods and Devils, Family',
@@ -1146,7 +1209,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v15538',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekopara_1,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         sequels: [
             'https://vndb.org/v17763',
             'https://vndb.org/v18713',
@@ -1163,7 +1229,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17763',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekopara_0,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v15538',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Cafe, Dousei, Polyamory',
@@ -1175,7 +1244,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v18713',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekopara_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v15538',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Cafe, Dousei, Polyamory',
@@ -1187,7 +1259,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v19385',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekopara_3,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v15538',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Cafe, Dousei, Polyamory',
@@ -1199,7 +1274,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26052',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekopara_4,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v15538',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Cafe, Dousei, Polyamory',
@@ -1212,9 +1290,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: noble_works,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Secret Identity, Dousei',
@@ -1227,9 +1305,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: dracu_riot,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Urban Fantasy, Vampires',
@@ -1241,7 +1319,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20433',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: [
             'https://vndb.org/v22105',
             'https://vndb.org/v22106',
@@ -1259,7 +1337,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22105',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin_plus_nachi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Fantasy, Catgirls',
@@ -1271,7 +1349,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22106',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin_plus_saiha,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Fantasy, Kunoichi',
@@ -1283,7 +1361,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22282',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Fantasy, Catgirls',
@@ -1296,8 +1374,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin_2_plus,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
@@ -1310,7 +1388,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v24872',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: neko_nin_3,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v20433',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Fantasy, Catgirls',
@@ -1322,7 +1400,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17823',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: wagahigh,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Slice of Life, Student Club',
         descriptionSecondRowText: 'School Life Comedy',
@@ -1333,7 +1414,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v9879',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: tsujidou,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Central Heroine, Delinquents',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1344,7 +1428,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v11856',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: fureraba,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v15602'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dating Sim, Slice of Life',
@@ -1357,8 +1444,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: fureraba_fd,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v11856',
         genreFocus: GenreFocus.ROM_COM,
@@ -1371,7 +1458,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21552',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: making_lovers,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v22594'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dating Sim, Adult Life',
@@ -1384,8 +1474,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: making_lovers_after,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v21552',
         genreFocus: GenreFocus.ROM_COM,
@@ -1398,7 +1488,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v24320',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: sugar_style,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dormitory, University',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1409,7 +1502,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26765',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: harem_kingdom,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Polyamory, Isekai',
         descriptionSecondRowText: 'King Protagonist',
@@ -1420,7 +1516,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v14887',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: primal_hearts,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v17038'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Student Council, Politics',
@@ -1432,7 +1531,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17038',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: primal_hearts_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         originalGame: 'https://vndb.org/v14887',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Student Council, Politics',
@@ -1444,7 +1546,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v12559',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: mml,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Childhood Promise, Reunion',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1455,7 +1560,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v415',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: damekoi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LADDER_STRUCTURE],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.LADDER_STRUCTURE
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Love Triangle, Dousei',
         descriptionSecondRowText: 'Central Heroine',
@@ -1467,9 +1575,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: onikiss,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dousei, Imouto, Kissing',
@@ -1481,7 +1589,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21956',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: ixshetell,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Love Triangle, Deredere',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1493,9 +1604,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: amatarasu_riddle,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Maggic, Slice of Life, Comedy',
@@ -1507,7 +1618,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v26310',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: ninnin_days,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: [
             'https://vndb.org/v32805',
             'https://vndb.org/v27751',
@@ -1524,7 +1635,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v32805',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: ninnin_days_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         originalGame: 'https://vndb.org/v26310',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Ninja Heroine, Dousei',
@@ -1536,7 +1650,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v27751',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: troubledays,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v26310',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Succubus, Modern Days',
@@ -1548,7 +1662,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v28345',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: kukkoro_days,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v26310',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Knight Heroine, Modern Day',
@@ -1560,7 +1674,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v31363',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: idoldays,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         originalGame: 'https://vndb.org/v26310',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Idols, Dousei',
@@ -1572,7 +1689,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v25170',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: nekomiko,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Catgirls, Polyamory',
         descriptionSecondRowText: 'Shinto Shrine',
@@ -1583,7 +1703,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v29482',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: sextet_1,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: ['https://vndb.org/v31090', 'https://vndb.org/v29482'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Isekai, Polyamory',
@@ -1595,7 +1715,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v31090',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: sextet_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v29482',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Isekai, Polyamory',
@@ -1607,7 +1727,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v29482',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: sextet_3,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v29482',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Isekai, Polyamory',
@@ -1619,7 +1739,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v18974',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: karakara,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         sequels: ['https://vndb.org/v20980'],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dystopia, Kemonomimi',
@@ -1631,7 +1754,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20980',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: karakara_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         originalGame: 'https://vndb.org/v18974',
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dystopia, Kemonomimi',
@@ -1643,7 +1769,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v15064',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: yuki_koi_melt,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Winter Club, School Life',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1654,7 +1783,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v20622',
         playtime: PlaytimeLength.LONG,
         thumbnailSource: mashimaro,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Cafe, Part-time Job',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1666,9 +1798,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: kamiyaba,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Goddess Heroine, Comedy',
@@ -1680,7 +1812,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v18149',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: otome_domain,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Trap MC, All-girls School',
         descriptionSecondRowText: 'School Dormitory',
@@ -1691,7 +1826,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v34004',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: pet_jijou,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Angels and Demons, Dousei',
         descriptionSecondRowText: 'Deredere Heroine',
@@ -1702,7 +1840,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v71',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: yukizakura,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Countryside, Winter',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1713,7 +1854,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v2622',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: osadai,
-        attributes: [Attribute.FLOATING_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.FLOATING_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         sequels: ['https://vndb.org/v4981'],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Science Fiction, Parody',
@@ -1725,7 +1869,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v4981',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: osadai_fd,
-        attributes: [Attribute.FLOATING_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.FLOATING_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         originalGame: 'https://vndb.org/v2622',
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Science Fiction, Parody',
@@ -1737,7 +1884,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v5240',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: ikikoi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Slice of life, High School',
         descriptionSecondRowText: 'Slapstick',
@@ -1749,9 +1899,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.VERY_LONG,
         thumbnailSource: majikoi,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         sequels: [
             'https://vndb.org/v6245',
@@ -1771,9 +1921,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: majikoi_s,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1787,8 +1937,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: majikoi_a1,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1802,8 +1952,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: majikoi_a2,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1817,8 +1967,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: majikoi_a3,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1832,8 +1982,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: majikoi_a4,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v1143',
         genreFocus: GenreFocus.COMEDY,
@@ -1847,9 +1997,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: sakura_sakura,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Dousei, Slice of Life Comedy',
@@ -1861,7 +2011,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v19444',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: sankaku_renai,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Slice of Life, Group of Friends',
         descriptionSecondRowText: 'Comedic Love Triangle',
@@ -1872,7 +2025,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v25366',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: koikari,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Love Triangle, Comedy',
         descriptionSecondRowText: 'Rent-a-boyfriend',
@@ -1884,9 +2040,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: onigokko,
         attributes: [
-            Attribute.FLOATING_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.FLOATING_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Japanese Mythology, Comedy',
@@ -1899,9 +2055,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: noratoto,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         sequels: ['https://vndb.org/v19841'],
         genreFocus: GenreFocus.COMEDY,
@@ -1915,9 +2071,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: noratoto_2,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v18148',
         genreFocus: GenreFocus.COMEDY,
@@ -1930,7 +2086,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v28634',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: drapri,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: [
             'https://vndb.org/v30029',
             'https://vndb.org/v30649',
@@ -1947,8 +2103,8 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: drapri_plus,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v28634',
         genreFocus: GenreFocus.COMEDY,
@@ -1961,7 +2117,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v30649',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: drapri_2,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v28634',
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Dragons, Love Triangle',
@@ -1973,7 +2129,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v37055',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: drapri_3,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v28634',
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Dragons, Love Triangle',
@@ -1985,7 +2141,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v31669',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: kemonomichi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Mahou Shoujo, Idols',
         descriptionSecondRowText: 'Slice of Life Comedy',
@@ -1996,7 +2152,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v28633',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: renai_royale,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Comedy, 4th Wall Breaking',
         descriptionSecondRowText: 'Love Triangle',
@@ -2008,9 +2167,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: lovekami,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         sequels: ['https://vndb.org/v21188'],
         genreFocus: GenreFocus.COMEDY,
@@ -2024,9 +2183,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: lovekami_trouble,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.BRANCHING_PLOT,
-            Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT,
+            FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
         ],
         originalGame: 'https://vndb.org/v20337',
         genreFocus: GenreFocus.COMEDY,
@@ -2039,7 +2198,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v4017',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: koi_iro_chu,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Cupids, Supernatural',
         descriptionSecondRowText: 'Student Life Comedy',
@@ -2050,7 +2212,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v21458',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: momoiro_closet,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Otaku, Slice of Life',
         descriptionSecondRowText: 'Cosplay',
@@ -2062,9 +2227,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.LONG,
         thumbnailSource: koikuma,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.BRANCHING_PLOT
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.BRANCHING_PLOT
         ],
         sequels: ['https://vndb.org/v18791'],
         genreFocus: GenreFocus.NUKIGE,
@@ -2078,9 +2243,9 @@ export const visualNovelData: VisualNovelProps[] = [
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: koikuma_fd,
         attributes: [
-            Attribute.ADV_TEXTBOX,
-            Attribute.UNLOCKABLE_ROUTES,
-            Attribute.SCENARIO_SELECTION
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.UNLOCKABLE_ROUTES,
+            FilterAttribute.SCENARIO_SELECTION
         ],
         originalGame: 'https://vndb.org/v17515',
         genreFocus: GenreFocus.NUKIGE,
@@ -2093,7 +2258,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v16150',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: kanojo_no_seiiki,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Master and Servant, Comedy',
         descriptionSecondRowText: 'Single Heroine',
@@ -2104,7 +2272,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22658',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: uchi_no_kanojo,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         sequels: ['https://vndb.org/v22725', 'https://vndb.org/v22726'],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Deredere, Dousei',
@@ -2116,7 +2284,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22725',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: uchi_no_imouto,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v22658',
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Forbidden Love, Dousei',
@@ -2128,7 +2296,7 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22726',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: uchi_no_koibito,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.LINEAR_PLOT],
+        attributes: [FilterAttribute.ADV_TEXTBOX, FilterAttribute.LINEAR_PLOT],
         originalGame: 'https://vndb.org/v22658',
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Gyaru, Dousei',
@@ -2140,7 +2308,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17337',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: tenkiame,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Countryside, Kitsune',
         descriptionSecondRowText: 'Slice of Life',
@@ -2151,7 +2322,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v27276',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: wabisabi,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.KINETIC_NOVEL],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.KINETIC_NOVEL
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Countryside, Kemonomimi',
         descriptionSecondRowText: 'Goddess Heroine',
@@ -2162,7 +2336,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v12505',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: nyan_cafe,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Cat Cafe, Polyamory',
         descriptionSecondRowText: 'Adult Protagonist',
@@ -2173,7 +2350,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v17997',
         playtime: PlaytimeLength.MEDIUM,
         thumbnailSource: wan_nyan,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Deredere Heroines, Baking',
         descriptionSecondRowText: 'Animal Cafe',
@@ -2184,7 +2364,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v28834',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: honey,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Deredere Heroine, Pillow Talk',
         descriptionSecondRowText: 'Teacher Heroine',
@@ -2195,7 +2378,10 @@ export const visualNovelData: VisualNovelProps[] = [
         vndbLink: 'https://vndb.org/v22483',
         playtime: PlaytimeLength.SHORT,
         thumbnailSource: oneyuu,
-        attributes: [Attribute.ADV_TEXTBOX, Attribute.BRANCHING_PLOT],
+        attributes: [
+            FilterAttribute.ADV_TEXTBOX,
+            FilterAttribute.BRANCHING_PLOT
+        ],
         genreFocus: GenreFocus.NUKIGE,
         descriptionFirstRowText: 'Older Sister, Secret Romance',
         descriptionSecondRowText: 'Single Heroine',

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -199,6 +199,7 @@ export interface VisualNovelProps {
     descriptionSecondRowText: string;
     translationReleaseDate?: number;
     isUpcomingRelease?: boolean;
+    isRecommended?: boolean;
 }
 
 export const visualNovelData: VisualNovelProps[] = [
@@ -215,7 +216,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Group of Friends, Sports',
         descriptionSecondRowText: 'Competition',
-        translationReleaseDate: Date.parse('2019-09-27')
+        translationReleaseDate: Date.parse('2019-09-27'),
+        isRecommended: true
     },
     {
         name: 'Aokana EXTRA1',

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -466,7 +466,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORYLINE,
         descriptionFirstRowText: 'Superpowers, Suspense',
         descriptionSecondRowText: 'Urban Fantasy',
-        translationReleaseDate: Date.parse('2019-01-31')
+        translationReleaseDate: Date.parse('2019-01-31'),
+        isRecommended: true
     },
     {
         name: '9-nine-:Episode 2',
@@ -534,7 +535,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Blondes, School Life Comedy',
         descriptionSecondRowText: 'Reunion',
-        translationReleaseDate: Date.parse('2021-06-11')
+        translationReleaseDate: Date.parse('2021-06-11'),
+        isRecommended: true
     },
     {
         name: 'Kinkoi GT',
@@ -597,7 +599,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Urban Fantasy, Mystery',
         descriptionSecondRowText: 'Library Club',
-        translationReleaseDate: Date.parse('2019-03-23')
+        translationReleaseDate: Date.parse('2019-03-23'),
+        isRecommended: true
     },
     {
         name: 'Tamayura Mirai',
@@ -747,7 +750,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Occult Club, Witches',
         descriptionSecondRowText: 'Slice of Life Comedy',
-        translationReleaseDate: Date.parse('2018-10-26')
+        translationReleaseDate: Date.parse('2018-10-26'),
+        isRecommended: true
     },
     {
         name: 'Princess Evangile',
@@ -762,7 +766,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'School Dormitory, Drama',
         descriptionSecondRowText: 'All-girls School',
-        translationReleaseDate: Date.parse('2015-03-27')
+        translationReleaseDate: Date.parse('2015-03-27'),
+        isRecommended: true
     },
     {
         name: 'Princess Evangile WH',
@@ -806,7 +811,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Student Club, Slice of Life',
         descriptionSecondRowText: 'High School',
-        translationReleaseDate: Date.parse('2017-05-06')
+        translationReleaseDate: Date.parse('2017-05-06'),
+        isRecommended: true
     },
     {
         name: 'Cafe Stella',
@@ -851,7 +857,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Secret Identity, Slice of Life',
         descriptionSecondRowText: 'Supernatural',
-        translationReleaseDate: Date.parse('2020-12-18')
+        translationReleaseDate: Date.parse('2020-12-18'),
+        isRecommended: true
     },
     {
         name: 'Hinatabokko',
@@ -1003,7 +1010,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROMANCE,
         descriptionFirstRowText: 'Slice of Life, Festival',
         descriptionSecondRowText: 'Passage of Time',
-        translationReleaseDate: Date.parse('2019-04-03')
+        translationReleaseDate: Date.parse('2019-04-03'),
+        isRecommended: true
     },
     {
         name: 'Yotsunoha',
@@ -1409,7 +1417,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Slice of Life, Student Club',
         descriptionSecondRowText: 'School Life Comedy',
-        translationReleaseDate: Date.parse('2017-07-27')
+        translationReleaseDate: Date.parse('2017-07-27'),
+        isRecommended: true
     },
     {
         name: 'Tsujidou',
@@ -1438,7 +1447,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dating Sim, Slice of Life',
         descriptionSecondRowText: 'School Life Comedy',
-        translationReleaseDate: Date.parse('2018-03-19')
+        translationReleaseDate: Date.parse('2018-03-19'),
+        isRecommended: true
     },
     {
         name: 'Fureraba Mini FD',
@@ -1468,7 +1478,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Dating Sim, Adult Life',
         descriptionSecondRowText: 'Slice of Life Comedy',
-        translationReleaseDate: Date.parse('2020-04-03')
+        translationReleaseDate: Date.parse('2020-04-03'),
+        isRecommended: true
     },
     {
         name: 'Making*Lovers After',
@@ -1915,7 +1926,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Martial Arts, Group of Friends',
         descriptionSecondRowText: 'Slice of Life Comedy',
-        translationReleaseDate: Date.parse('2015-03-10')
+        translationReleaseDate: Date.parse('2015-03-10'),
+        isRecommended: true
     },
     {
         name: 'Majikoi S',
@@ -2161,7 +2173,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Comedy, 4th Wall Breaking',
         descriptionSecondRowText: 'Love Triangle',
-        translationReleaseDate: Date.parse('2022-09-30')
+        translationReleaseDate: Date.parse('2022-09-30'),
+        isRecommended: true
     },
     {
         name: 'Lovekami',

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -183,7 +183,8 @@ import nekopara_after from '../../assets/thumbnails/nekopara_after.jpg';
 import kemonomichi_love_plus from '../../assets/thumbnails/kemonomichi_love_plus.jpg';
 import kemonomichi_2 from '../../assets/thumbnails/kemonomichi_2.jpg';
 import konosora_snow from '../../assets/thumbnails/konosora_snow.jpg';
-import { Attribute, GenreFocus, PlaytimeLength } from './VisualNovelCard';
+import { Attribute, GenreFocus } from './utils';
+import { PlaytimeLength } from './utils';
 
 export interface VisualNovelProps {
     name: string;

--- a/src/views/HomePage/Chart/visualNovelData.ts
+++ b/src/views/HomePage/Chart/visualNovelData.ts
@@ -229,7 +229,8 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORYLINE, //TODO Romance?
         descriptionFirstRowText: 'Group of Friends, Pure Love',
         descriptionSecondRowText: 'Single Heroine',
-        translationReleaseDate: Date.parse('2020-11-06')
+        translationReleaseDate: Date.parse('2020-11-06'),
+        isRecommended: true
     },
     {
         name: 'Aokana EXTRA2',

--- a/src/views/HomePage/Chart/visualNovelData.tsx
+++ b/src/views/HomePage/Chart/visualNovelData.tsx
@@ -200,6 +200,7 @@ export interface VisualNovelProps {
     translationReleaseDate?: number;
     isUpcomingRelease?: boolean;
     isRecommended?: boolean;
+    recommendedDescription?: React.ReactNode;
 }
 
 export const visualNovelData: VisualNovelProps[] = [
@@ -217,7 +218,8 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Group of Friends, Sports',
         descriptionSecondRowText: 'Competition',
         translationReleaseDate: Date.parse('2019-09-27'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: <div>talent good</div>
     },
     {
         name: 'Aokana EXTRA1',

--- a/src/views/HomePage/Chart/visualNovelData.tsx
+++ b/src/views/HomePage/Chart/visualNovelData.tsx
@@ -219,7 +219,15 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionSecondRowText: 'Competition',
         translationReleaseDate: Date.parse('2019-09-27'),
         isRecommended: true,
-        recommendedDescription: <div>talent good</div>
+        recommendedDescription: (
+            <>
+                Talent good. Sprite is a company with very high production
+                value, which you can see in Aokana's art, OST, and story
+                writing. This game has a strong emphasis on its sports-based
+                story, however there are still lots of moments of cute girls
+                being cute.
+            </>
+        )
     },
     {
         name: 'Aokana EXTRA1',
@@ -469,7 +477,16 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Superpowers, Suspense',
         descriptionSecondRowText: 'Urban Fantasy',
         translationReleaseDate: Date.parse('2019-01-31'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                Episodic VN, though all entries have been translated at this
+                point. Somewhat debateable if this could be considered a moege,
+                as there's a good amount of action and mystery in each episode.
+                However there is still a noticeable presence of slice-of-life
+                moments and romance.
+            </>
+        )
     },
     {
         name: '9-nine-:Episode 2',
@@ -537,8 +554,7 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.STORY_ROMANCE,
         descriptionFirstRowText: 'Blondes, School Life Comedy',
         descriptionSecondRowText: 'Reunion',
-        translationReleaseDate: Date.parse('2021-06-11'),
-        isRecommended: true
+        translationReleaseDate: Date.parse('2021-06-11')
     },
     {
         name: 'Kinkoi GT',
@@ -602,7 +618,16 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Urban Fantasy, Mystery',
         descriptionSecondRowText: 'Library Club',
         translationReleaseDate: Date.parse('2019-03-23'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                For those interested in a good plot, Daitoshokan is a good game
+                to start off with. There's a stronger focus on the main
+                character's development compared to other moege, and the mystery
+                in the story is something you can be invested in. There is still
+                a good amount of romance, but the focus is shifted away from it.
+            </>
+        )
     },
     {
         name: 'Tamayura Mirai',
@@ -753,7 +778,17 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Occult Club, Witches',
         descriptionSecondRowText: 'Slice of Life Comedy',
         translationReleaseDate: Date.parse('2018-10-26'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                Yuzusoft is probably the largest moege developer, and Sanoba
+                Witch is a popular entry of theirs (You may spot some of their
+                characters hidden on this site!). There's a light supernatural
+                element to the story, but it's mainly just window dressing for
+                interacting with cute girls. Some routes are more heavily
+                focused on their route conflict than others.
+            </>
+        )
     },
     {
         name: 'Princess Evangile',
@@ -769,7 +804,17 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'School Dormitory, Drama',
         descriptionSecondRowText: 'All-girls School',
         translationReleaseDate: Date.parse('2015-03-27'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                A very pure moege, that also contains moments of action and
+                drama. The setting is rather unique and the main character is
+                somewhat of a power fantasy, being the focus of attention to the
+                large cast of heroines. There are lots of characters to enjoy,
+                and pretty much all routelets get their time to shine in the
+                Fandisc.
+            </>
+        )
     },
     {
         name: 'Princess Evangile WH',
@@ -814,7 +859,15 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Student Club, Slice of Life',
         descriptionSecondRowText: 'High School',
         translationReleaseDate: Date.parse('2017-05-06'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                A deep part of /vn/ culture. This is required reading. It's so
+                bad that it eventually becomes enjoyable to read. Unfortunately
+                we lost one of the best fan translation teams to this evil
+                company.
+            </>
+        )
     },
     {
         name: 'Cafe Stella',
@@ -860,7 +913,17 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Secret Identity, Slice of Life',
         descriptionSecondRowText: 'Supernatural',
         translationReleaseDate: Date.parse('2020-12-18'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                Riddle Joker is a prime example of a modern Yuzusoft moege. The
+                setting is somewhat fantastical and the plot is technically
+                serious, but it's still a pretty light-hearted VN. Due to the
+                consistency of Yuzusoft games, if you've read a few of them and
+                haven't enjoyed a single one, this might not be the genre for
+                you.
+            </>
+        )
     },
     {
         name: 'Hinatabokko',
@@ -1013,7 +1076,16 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Slice of Life, Festival',
         descriptionSecondRowText: 'Passage of Time',
         translationReleaseDate: Date.parse('2019-04-03'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                This is the same developer who made Hatsukoi 1/1. Hoshi Ori Yume
+                Mirai is so bereft of conflict and drama, and the fact that the
+                "after-story" for each heroine is about half of their route's
+                length, means that you'll either love the slow pacing or utterly
+                despise it.
+            </>
+        )
     },
     {
         name: 'Yotsunoha',
@@ -1420,7 +1492,17 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Slice of Life, Student Club',
         descriptionSecondRowText: 'School Life Comedy',
         translationReleaseDate: Date.parse('2017-07-27'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                One of the more standard moege entries in this chart. Like the
+                title implies, the unique quirk with the heroines of Wagamama
+                High Spec is their relatively selfish behaviour. However that's
+                not to say that they're dislikeable, they're just more strongly
+                opinionated. A good balance of romance and comedy, with just a
+                tiny emphasis on it's plot.
+            </>
+        )
     },
     {
         name: 'Tsujidou',
@@ -1450,7 +1532,16 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Dating Sim, Slice of Life',
         descriptionSecondRowText: 'School Life Comedy',
         translationReleaseDate: Date.parse('2018-03-19'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                One of the older games here, Fureraba is pretty extreme with
+                it's comedy at times, but is also another heavily ichaicha
+                focused entry from Smee. The route selection system in this game
+                is closer to a dating sim than your normal moege, where you ask
+                heroines questions and need to choose the best response.
+            </>
+        )
     },
     {
         name: 'Fureraba Mini FD',
@@ -1481,7 +1572,18 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Dating Sim, Adult Life',
         descriptionSecondRowText: 'Slice of Life Comedy',
         translationReleaseDate: Date.parse('2020-04-03'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                The setting for Making*Lovers is unique compared to most other
+                moege, where the main character is a working adult who doesn't
+                live with their parents. The common route is very short and you
+                get into the process of forming a relationship very quickly.
+                There's a fun gimmick of being able to plan where some of the
+                dates take place. Great for those that like comedy and ichaicha,
+                with this entry leaning a bit more into the latter.
+            </>
+        )
     },
     {
         name: 'Making*Lovers After',
@@ -1539,7 +1641,16 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.ROM_COM,
         descriptionFirstRowText: 'Student Council, Politics',
         descriptionSecondRowText: 'Slice of Life Comedy',
-        translationReleaseDate: Date.parse('2021-07-30')
+        translationReleaseDate: Date.parse('2021-07-30'),
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                A gateway to moenukige, for those that are interested. If you
+                like this game, there's also the other translated Marmalade
+                games (including the sequel). All of them have high production
+                quality and a nice art style to look at.
+            </>
+        )
     },
     {
         name: 'PRIMAL×HEARTS 2',
@@ -1929,7 +2040,19 @@ export const visualNovelData: VisualNovelProps[] = [
         descriptionFirstRowText: 'Martial Arts, Group of Friends',
         descriptionSecondRowText: 'Slice of Life Comedy',
         translationReleaseDate: Date.parse('2015-03-10'),
-        isRecommended: true
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                Lots of choices you can make, with a huge cast of characters.
+                It's pretty lengthy and has several fandiscs, so there's a lot
+                to sink your teeth into if this is something you enjoy. That
+                being said, this isn't your typical moege, as there's a bit more
+                drama and plot here, as well as having actual fight scenes. If
+                the above sounds interesting, go ahead and try it out.
+                Otherwise, feel free to check something else out, as this is far
+                from the norm for moege.
+            </>
+        )
     },
     {
         name: 'Majikoi S',
@@ -2048,7 +2171,16 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Love Triangle, Comedy',
         descriptionSecondRowText: 'Rent-a-boyfriend',
-        translationReleaseDate: Date.parse('2021-10-22')
+        translationReleaseDate: Date.parse('2021-10-22'),
+        isRecommended: true,
+        recommendedDescription: (
+            <>
+                The most popular ASa Project game on /vn/, this company is
+                generally known for some pretty over the top comedy and fourth
+                wall breaks. The story is rather silly and not meant to be taken
+                seriously, with the focus being on the heroines themselves.
+            </>
+        )
     },
     {
         name: 'Onigokko!',
@@ -2175,8 +2307,7 @@ export const visualNovelData: VisualNovelProps[] = [
         genreFocus: GenreFocus.COMEDY,
         descriptionFirstRowText: 'Comedy, 4th Wall Breaking',
         descriptionSecondRowText: 'Love Triangle',
-        translationReleaseDate: Date.parse('2022-09-30'),
-        isRecommended: true
+        translationReleaseDate: Date.parse('2022-09-30')
     },
     {
         name: 'Lovekami',

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -5,7 +5,8 @@ import React, { useState } from 'react';
 import Background from '../assets/thumbnails/Background.jpg';
 import { SortingOption } from '../SideNav/LegendData';
 import { SIDE_NAV_WIDTH } from '../SideNav/utils';
-import { PlaytimeLength, GenreFocus, Attribute } from './Chart/VisualNovelCard';
+import { GenreFocus, Attribute } from './Chart/utils';
+import { PlaytimeLength } from './Chart/utils';
 export const HomePage: React.FC = () => {
     const [selectedSortingOptions, setSelectedSortingOptions] = useState<
         SortingOption[]

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -21,8 +21,12 @@ export const HomePage: React.FC = () => {
     >([]);
     const [isSelectedHasSequelFilter, setIsSelectedHasSequelFilter] =
         useState<boolean>(false);
-    const [isSelectedHideSequelFilter, setIsSelectedHideSequelFilter] =
-        useState<boolean>(true);
+    const [isSelectedShowSequelFilter, setIsSelectedShowSequelFilter] =
+        useState<boolean>(false);
+    const [
+        isSelectedShowRecommendedFilter,
+        setIsSelectedShowRecommendedFilter
+    ] = useState<boolean>(true);
 
     const [isInPopupView, setIsInPopupView] = useState<boolean>(false);
 
@@ -74,7 +78,8 @@ export const HomePage: React.FC = () => {
         setSelectedGenreFocusFilter(null);
         setSelectedFilterAttributes([]);
         setIsSelectedHasSequelFilter(false);
-        setIsSelectedHideSequelFilter(false);
+        setIsSelectedShowSequelFilter(false);
+        setIsSelectedShowRecommendedFilter(false);
     };
 
     return (
@@ -100,8 +105,14 @@ export const HomePage: React.FC = () => {
                 }
                 isSelectedHasSequelFilter={isSelectedHasSequelFilter}
                 setIsSelectedHasSequelFilter={setIsSelectedHasSequelFilter}
-                isSelectedHideSequelFilter={isSelectedHideSequelFilter}
-                setIsSelectedHideSequelFilter={setIsSelectedHideSequelFilter}
+                isSelectedShowSequelFilter={isSelectedShowSequelFilter}
+                setIsSelectedShowSequelFilter={setIsSelectedShowSequelFilter}
+                isSelectedShowRecommendedFilter={
+                    isSelectedShowRecommendedFilter
+                }
+                setIsSelectedShowRecommendedFilter={
+                    setIsSelectedShowRecommendedFilter
+                }
                 isInPopupView={isInPopupView}
                 clearFilters={clearFilters}
             />
@@ -113,7 +124,10 @@ export const HomePage: React.FC = () => {
                 selectedGenreFocusFilter={selectedGenreFocusFilter}
                 selectedFilterAttributes={selectedFilterAttributes}
                 isSelectedHasSequelFilter={isSelectedHasSequelFilter}
-                isSelectedHideSequelFilter={isSelectedHideSequelFilter}
+                isSelectedShowSequelFilter={isSelectedShowSequelFilter}
+                isSelectedShowRecommendedFilter={
+                    isSelectedShowRecommendedFilter
+                }
                 setIsInPopupView={setIsInPopupView}
             />
         </Container>

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { MoegeChart } from './Chart/MoegeChart';
 import { SideNav } from '../SideNav/SideNav';
 import React, { useState } from 'react';
-import Background from '../assets/thumbnails/Background.jpg';
+
 import { MiscellaneousSortingOption } from '../SideNav/LegendData';
 import { SIDE_NAV_WIDTH } from '../SideNav/utils';
 import { GenreFocus, FilterAttribute } from './Chart/utils';
@@ -138,6 +138,4 @@ const Container = styled.div`
     padding-left: calc(${SIDE_NAV_WIDTH}px + 20px);
     padding-bottom: 40px;
     margin-bottom: -10px;
-    min-height: 96vh;
-    background: fixed url(${Background}) bottom right no-repeat;
 `;

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -45,13 +45,11 @@ export const HomePage: React.FC = () => {
             ? setSelectedPlaytimeFilter(null)
             : setSelectedPlaytimeFilter(value);
     };
-
     const handleSetSelectedGenreFocusFilter = (value: GenreFocus) => {
         selectedGenreFocusFilter === value
             ? setSelectedGenreFocusFilter(null)
             : setSelectedGenreFocusFilter(value);
     };
-
     const handleSetSelectedAttributesFilters = (value: Attribute) => {
         if (selectedAttributesFilters.some(attribute => attribute === value)) {
             setSelectedAttributesFilters(
@@ -63,7 +61,6 @@ export const HomePage: React.FC = () => {
             setSelectedAttributesFilters([...selectedAttributesFilters, value]);
         }
     };
-
     const clearFilters = () => {
         setSelectedSortingOptions([]);
         setSelectedPlaytimeFilter(null);

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -3,20 +3,21 @@ import { MoegeChart } from './Chart/MoegeChart';
 import { SideNav } from '../SideNav/SideNav';
 import React, { useState } from 'react';
 import Background from '../assets/thumbnails/Background.jpg';
-import { SortingOption } from '../SideNav/LegendData';
+import { MiscellaneousSortingOption } from '../SideNav/LegendData';
 import { SIDE_NAV_WIDTH } from '../SideNav/utils';
-import { GenreFocus, Attribute } from './Chart/utils';
+import { GenreFocus, FilterAttribute } from './Chart/utils';
 import { PlaytimeLength } from './Chart/utils';
 export const HomePage: React.FC = () => {
-    const [selectedSortingOptions, setSelectedSortingOptions] = useState<
-        SortingOption[]
-    >([]);
+    const [
+        selectedMiscellaneousSortingOptions,
+        setSelectedMiscellaneousSortingOptions
+    ] = useState<MiscellaneousSortingOption[]>([]);
     const [selectedPlaytimeFilter, setSelectedPlaytimeFilter] =
         useState<PlaytimeLength | null>(null);
     const [selectedGenreFocusFilter, setSelectedGenreFocusFilter] =
         useState<GenreFocus | null>(null);
-    const [selectedAttributesFilters, setSelectedAttributesFilters] = useState<
-        Attribute[]
+    const [selectedFilterAttributes, setSelectedFilterAttributes] = useState<
+        FilterAttribute[]
     >([]);
     const [isSelectedHasSequelFilter, setIsSelectedHasSequelFilter] =
         useState<boolean>(false);
@@ -25,19 +26,24 @@ export const HomePage: React.FC = () => {
 
     const [isInPopupView, setIsInPopupView] = useState<boolean>(false);
 
-    const handleSetSelectedSortingOptions = (value: SortingOption) => {
+    const handleSetSelectedMiscellaneousSortingOptions = (
+        value: MiscellaneousSortingOption
+    ) => {
         if (
-            selectedSortingOptions.some(
+            selectedMiscellaneousSortingOptions.some(
                 sortingOption => sortingOption === value
             )
         ) {
-            setSelectedSortingOptions(
-                selectedSortingOptions.filter(
+            setSelectedMiscellaneousSortingOptions(
+                selectedMiscellaneousSortingOptions.filter(
                     sortingOption => sortingOption !== value
                 )
             );
         } else {
-            setSelectedSortingOptions([...selectedSortingOptions, value]);
+            setSelectedMiscellaneousSortingOptions([
+                ...selectedMiscellaneousSortingOptions,
+                value
+            ]);
         }
     };
 
@@ -51,22 +57,22 @@ export const HomePage: React.FC = () => {
             ? setSelectedGenreFocusFilter(null)
             : setSelectedGenreFocusFilter(value);
     };
-    const handleSetSelectedAttributesFilters = (value: Attribute) => {
-        if (selectedAttributesFilters.some(attribute => attribute === value)) {
-            setSelectedAttributesFilters(
-                selectedAttributesFilters.filter(
+    const handleSetSelectedFilterAttributes = (value: FilterAttribute) => {
+        if (selectedFilterAttributes.some(attribute => attribute === value)) {
+            setSelectedFilterAttributes(
+                selectedFilterAttributes.filter(
                     attribute => attribute !== value
                 )
             );
         } else {
-            setSelectedAttributesFilters([...selectedAttributesFilters, value]);
+            setSelectedFilterAttributes([...selectedFilterAttributes, value]);
         }
     };
     const clearFilters = () => {
-        setSelectedSortingOptions([]);
+        setSelectedMiscellaneousSortingOptions([]);
         setSelectedPlaytimeFilter(null);
         setSelectedGenreFocusFilter(null);
-        setSelectedAttributesFilters([]);
+        setSelectedFilterAttributes([]);
         setIsSelectedHasSequelFilter(false);
         setIsSelectedHideSequelFilter(false);
     };
@@ -74,9 +80,11 @@ export const HomePage: React.FC = () => {
     return (
         <Container>
             <SideNav
-                selectedSortingOptions={selectedSortingOptions}
-                handleSetSelectedSortingOptions={
-                    handleSetSelectedSortingOptions
+                selectedMiscellaneousSortingOptions={
+                    selectedMiscellaneousSortingOptions
+                }
+                handleSetSelectedMiscellaneousSortingOptions={
+                    handleSetSelectedMiscellaneousSortingOptions
                 }
                 selectedPlaytimeFilter={selectedPlaytimeFilter}
                 handleSetSelectedPlaytimeFilter={
@@ -86,9 +94,9 @@ export const HomePage: React.FC = () => {
                 handleSetSelectedGenreFocusFilter={
                     handleSetSelectedGenreFocusFilter
                 }
-                selectedAttributesFilters={selectedAttributesFilters}
-                handleSetSelectedAttributesFilters={
-                    handleSetSelectedAttributesFilters
+                selectedFilterAttributes={selectedFilterAttributes}
+                handleSetSelectedFilterAttributes={
+                    handleSetSelectedFilterAttributes
                 }
                 isSelectedHasSequelFilter={isSelectedHasSequelFilter}
                 setIsSelectedHasSequelFilter={setIsSelectedHasSequelFilter}
@@ -98,10 +106,12 @@ export const HomePage: React.FC = () => {
                 clearFilters={clearFilters}
             />
             <MoegeChart
-                selectedSortingOptions={selectedSortingOptions}
+                selectedMiscellaneousSortingOptions={
+                    selectedMiscellaneousSortingOptions
+                }
                 selectedPlaytimeFilter={selectedPlaytimeFilter}
                 selectedGenreFocusFilter={selectedGenreFocusFilter}
-                selectedAttributesFilters={selectedAttributesFilters}
+                selectedFilterAttributes={selectedFilterAttributes}
                 isSelectedHasSequelFilter={isSelectedHasSequelFilter}
                 isSelectedHideSequelFilter={isSelectedHideSequelFilter}
                 setIsInPopupView={setIsInPopupView}

--- a/src/views/SideNav/AttributeItem.tsx
+++ b/src/views/SideNav/AttributeItem.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { AttributeProps } from './LegendData';
 import { LegendItemContainer, LegendLabel } from './utils';
-import { Attribute } from '../HomePage/Chart/utils';
+import { FilterAttribute } from '../HomePage/Chart/utils';
 import { ResponsiveButton } from '../utils';
 
 interface IProps extends AttributeProps {
     isSelected: boolean;
-    onClick: (value: Attribute) => void;
+    onClick: (value: FilterAttribute) => void;
 }
 
 export const AttributeItem: React.FC<IProps> = ({

--- a/src/views/SideNav/AttributeItem.tsx
+++ b/src/views/SideNav/AttributeItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AttributeProps } from './LegendData';
 import { LegendItemContainer, LegendLabel } from './utils';
-import { Attribute } from '../HomePage/Chart/VisualNovelCard';
+import { Attribute } from '../HomePage/Chart/utils';
 import { ResponsiveButton } from '../utils';
 
 interface IProps extends AttributeProps {

--- a/src/views/SideNav/FAQ.tsx
+++ b/src/views/SideNav/FAQ.tsx
@@ -30,11 +30,12 @@ export const FAQ: React.FC = () => {
                 question="ABOUT THE MOECHART"
                 answer={
                     <>
-                        This is <strong>not</strong> a recommendation chart, and
-                        no game will be rated here. The main purpose of the
-                        chart is to provide a complete list of moege (currently
-                        translated and future releases) sorted by 3
-                        content-related focuses. Additionally, some{' '}
+                        This is <strong>not</strong> a recommendation chart
+                        (though there are a few listed as recommended for
+                        beginners), and no game will be rated here. The main
+                        purpose of the chart is to provide a complete list of
+                        moege (currently translated and future releases) sorted
+                        by 3 content-related focuses. Additionally, some{' '}
                         <MoenukigeFont $outlineColour={COLOURS.GENRE.NUKIGE}>
                             Moenukige
                         </MoenukigeFont>{' '}

--- a/src/views/SideNav/FocusesOfInterest.tsx
+++ b/src/views/SideNav/FocusesOfInterest.tsx
@@ -11,7 +11,7 @@ import styled, { css } from 'styled-components';
 import { HelpIcon } from '../assets/icons/misc/HelpIcon';
 import { Row } from '../utils';
 import { AnimatePresence } from 'framer-motion';
-import { GenreFocus } from '../HomePage/Chart/VisualNovelCard';
+import { GenreFocus } from '../HomePage/Chart/utils';
 
 interface IProps {
     selectedGenreFocusFilter: GenreFocus | null;

--- a/src/views/SideNav/LegendData.ts
+++ b/src/views/SideNav/LegendData.ts
@@ -16,7 +16,7 @@ import { ReactElement } from 'react';
 import { ClockIcon } from '../assets/icons/sorting/ClockIcon';
 import { DiceIcon } from '../assets/icons/sorting/DiceIcon';
 import { ScenarioSelectionIcon } from '../assets/icons/attribute/ScenarioSelectionIcon';
-import { Attribute } from '../HomePage/Chart/utils';
+import { FilterAttribute } from '../HomePage/Chart/utils';
 import { PlaytimeLength } from '../HomePage/Chart/utils';
 
 interface BaseProps {
@@ -24,7 +24,7 @@ interface BaseProps {
     label: string;
 }
 export interface AttributeProps extends BaseProps {
-    type: Attribute;
+    type: FilterAttribute;
 }
 
 export interface PlaytimeProps extends BaseProps {
@@ -33,10 +33,10 @@ export interface PlaytimeProps extends BaseProps {
 }
 
 export interface SortingProps extends BaseProps {
-    option: SortingOption;
+    option: MiscellaneousSortingOption;
 }
 
-export enum SortingOption {
+export enum MiscellaneousSortingOption {
     CHRONOLOGICAL = 'CHRONOLOGICAL',
     RANDOM = 'RANDOM'
 }
@@ -68,73 +68,73 @@ export const playtimesList: PlaytimeProps[] = [
     }
 ];
 
-export const sortingList: SortingProps[] = [
+export const miscellaneousSortingToolsList: SortingProps[] = [
     {
         IconSVG: ClockIcon,
         label: 'Newest Releases',
-        option: SortingOption.CHRONOLOGICAL
+        option: MiscellaneousSortingOption.CHRONOLOGICAL
     },
     {
         IconSVG: DiceIcon,
         label: 'Random 10',
-        option: SortingOption.RANDOM
+        option: MiscellaneousSortingOption.RANDOM
     }
 ];
 
-export const attributesList: AttributeProps[] = [
+export const filterAttributesList: AttributeProps[] = [
     {
         IconSVG: ADVIcon,
         label: 'Part-screen Textbox',
-        type: Attribute.ADV_TEXTBOX
+        type: FilterAttribute.ADV_TEXTBOX
     },
     {
         IconSVG: NVLIcon,
         label: 'Full-screen Text-box',
-        type: Attribute.NVL_TEXTBOX
+        type: FilterAttribute.NVL_TEXTBOX
     },
     {
         IconSVG: FloatingTextIcon,
         label: 'Floating Textbox',
-        type: Attribute.FLOATING_TEXTBOX
+        type: FilterAttribute.FLOATING_TEXTBOX
     },
     {
         IconSVG: LockIcon,
         label: 'Unlockable Routes',
-        type: Attribute.UNLOCKABLE_ROUTES
+        type: FilterAttribute.UNLOCKABLE_ROUTES
     },
     {
         IconSVG: BranchIcon,
         label: 'Branching Plot',
-        type: Attribute.BRANCHING_PLOT
+        type: FilterAttribute.BRANCHING_PLOT
     },
     {
         IconSVG: LadderIcon,
         label: 'Ladder Structure',
-        type: Attribute.LADDER_STRUCTURE
+        type: FilterAttribute.LADDER_STRUCTURE
     },
     {
         IconSVG: TrueIcon,
         label: 'One True Route',
-        type: Attribute.TRUE_ROUTE
+        type: FilterAttribute.TRUE_ROUTE
     },
     {
         IconSVG: LinearPlotIcon,
         label: 'Linear Plot',
-        type: Attribute.LINEAR_PLOT
+        type: FilterAttribute.LINEAR_PLOT
     },
     {
         IconSVG: KineticNovelIcon,
         label: 'Kinetic Novel',
-        type: Attribute.KINETIC_NOVEL
+        type: FilterAttribute.KINETIC_NOVEL
     },
     {
         IconSVG: ScenarioSelectionIcon,
         label: 'Scenario Selection',
-        type: Attribute.SCENARIO_SELECTION
+        type: FilterAttribute.SCENARIO_SELECTION
     },
     {
         IconSVG: FrenchGirlIcon,
         label: 'Suitable for 12-year-old French Girls',
-        type: Attribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
+        type: FilterAttribute.SUITABLE_FOR_12_YEAR_OLD_FRENCH_GIRLS
     }
 ];

--- a/src/views/SideNav/LegendData.ts
+++ b/src/views/SideNav/LegendData.ts
@@ -16,7 +16,8 @@ import { ReactElement } from 'react';
 import { ClockIcon } from '../assets/icons/sorting/ClockIcon';
 import { DiceIcon } from '../assets/icons/sorting/DiceIcon';
 import { ScenarioSelectionIcon } from '../assets/icons/attribute/ScenarioSelectionIcon';
-import { Attribute, PlaytimeLength } from '../HomePage/Chart/VisualNovelCard';
+import { Attribute } from '../HomePage/Chart/utils';
+import { PlaytimeLength } from '../HomePage/Chart/utils';
 
 interface BaseProps {
     IconSVG: () => ReactElement;

--- a/src/views/SideNav/PlaytimeItem.tsx
+++ b/src/views/SideNav/PlaytimeItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PlaytimeProps } from './LegendData';
 import { LegendItemContainer, LegendLabel } from './utils';
-import { PlaytimeLength } from '../HomePage/Chart/VisualNovelCard';
+import { PlaytimeLength } from '../HomePage/Chart/utils';
 import { ResponsiveButton } from '../utils';
 
 interface IProps extends PlaytimeProps {

--- a/src/views/SideNav/SideNav.tsx
+++ b/src/views/SideNav/SideNav.tsx
@@ -14,28 +14,30 @@ import { FAQ } from './FAQ';
 import { FocusesOfInterest } from './FocusesOfInterest';
 
 import {
-    SortingOption,
-    attributesList,
+    MiscellaneousSortingOption,
+    filterAttributesList,
     playtimesList,
-    sortingList
+    miscellaneousSortingToolsList
 } from './LegendData';
 import { AttributeItem } from './AttributeItem';
 import { SortByItem } from './SortByItem';
 import { LegendItemContainer, LegendLabel, SIDE_NAV_WIDTH } from './utils';
 import { HasSequelIcon } from '../assets/icons/attribute/HasSequalIcon';
 import { IsSequelIcon } from '../assets/icons/attribute/IsSequelIcon';
-import { Attribute, GenreFocus } from '../HomePage/Chart/utils';
+import { FilterAttribute, GenreFocus } from '../HomePage/Chart/utils';
 import { PlaytimeLength } from '../HomePage/Chart/utils';
 
 interface IProps {
-    selectedSortingOptions: SortingOption[];
-    handleSetSelectedSortingOptions: (value: SortingOption) => void;
+    selectedMiscellaneousSortingOptions: MiscellaneousSortingOption[];
+    handleSetSelectedMiscellaneousSortingOptions: (
+        value: MiscellaneousSortingOption
+    ) => void;
     selectedPlaytimeFilter: PlaytimeLength | null;
     handleSetSelectedPlaytimeFilter: (value: PlaytimeLength) => void;
     selectedGenreFocusFilter: GenreFocus | null;
     handleSetSelectedGenreFocusFilter: (value: GenreFocus) => void;
-    selectedAttributesFilters: Attribute[];
-    handleSetSelectedAttributesFilters: (value: Attribute) => void;
+    selectedFilterAttributes: FilterAttribute[];
+    handleSetSelectedFilterAttributes: (value: FilterAttribute) => void;
     isSelectedHasSequelFilter: boolean;
     setIsSelectedHasSequelFilter: (value: boolean) => void;
     isSelectedHideSequelFilter: boolean;
@@ -45,14 +47,14 @@ interface IProps {
 }
 
 export const SideNav: React.FC<IProps> = ({
-    selectedSortingOptions,
-    handleSetSelectedSortingOptions,
+    selectedMiscellaneousSortingOptions,
+    handleSetSelectedMiscellaneousSortingOptions,
     selectedPlaytimeFilter,
     handleSetSelectedPlaytimeFilter,
     selectedGenreFocusFilter,
     handleSetSelectedGenreFocusFilter,
-    selectedAttributesFilters,
-    handleSetSelectedAttributesFilters,
+    selectedFilterAttributes,
+    handleSetSelectedFilterAttributes,
     isSelectedHasSequelFilter,
     setIsSelectedHasSequelFilter,
     isSelectedHideSequelFilter,
@@ -81,15 +83,15 @@ export const SideNav: React.FC<IProps> = ({
                             />
                         );
                     })}
-                    {attributesList.map(attribute => (
+                    {filterAttributesList.map(attribute => (
                         <AttributeItem
                             key={attribute.type}
-                            isSelected={selectedAttributesFilters.some(
+                            isSelected={selectedFilterAttributes.some(
                                 attributeFilter =>
                                     attributeFilter === attribute.type
                             )}
                             {...attribute}
-                            onClick={handleSetSelectedAttributesFilters}
+                            onClick={handleSetSelectedFilterAttributes}
                         />
                     ))}
                 </Section>
@@ -125,15 +127,17 @@ export const SideNav: React.FC<IProps> = ({
                         </ResponsiveButton>
                     </Row>
 
-                    {sortingList.map(sortingOption => {
+                    {miscellaneousSortingToolsList.map(sortingOption => {
                         return (
                             <SortByItem
                                 key={sortingOption.option}
-                                isSelected={selectedSortingOptions.some(
+                                isSelected={selectedMiscellaneousSortingOptions.some(
                                     option => option === sortingOption.option
                                 )}
                                 {...sortingOption}
-                                onClick={handleSetSelectedSortingOptions}
+                                onClick={
+                                    handleSetSelectedMiscellaneousSortingOptions
+                                }
                             />
                         );
                     })}

--- a/src/views/SideNav/SideNav.tsx
+++ b/src/views/SideNav/SideNav.tsx
@@ -26,6 +26,7 @@ import { HasSequelIcon } from '../assets/icons/attribute/HasSequalIcon';
 import { IsSequelIcon } from '../assets/icons/attribute/IsSequelIcon';
 import { FilterAttribute, GenreFocus } from '../HomePage/Chart/utils';
 import { PlaytimeLength } from '../HomePage/Chart/utils';
+import { StarIcon } from '../assets/icons/attribute/StarIcon';
 
 interface IProps {
     selectedMiscellaneousSortingOptions: MiscellaneousSortingOption[];
@@ -40,8 +41,10 @@ interface IProps {
     handleSetSelectedFilterAttributes: (value: FilterAttribute) => void;
     isSelectedHasSequelFilter: boolean;
     setIsSelectedHasSequelFilter: (value: boolean) => void;
-    isSelectedHideSequelFilter: boolean;
-    setIsSelectedHideSequelFilter: (value: boolean) => void;
+    isSelectedShowSequelFilter: boolean;
+    setIsSelectedShowSequelFilter: (value: boolean) => void;
+    isSelectedShowRecommendedFilter: boolean;
+    setIsSelectedShowRecommendedFilter: (value: boolean) => void;
     isInPopupView: boolean;
     clearFilters: () => void;
 }
@@ -57,8 +60,10 @@ export const SideNav: React.FC<IProps> = ({
     handleSetSelectedFilterAttributes,
     isSelectedHasSequelFilter,
     setIsSelectedHasSequelFilter,
-    isSelectedHideSequelFilter,
-    setIsSelectedHideSequelFilter,
+    isSelectedShowSequelFilter,
+    setIsSelectedShowSequelFilter,
+    isSelectedShowRecommendedFilter,
+    setIsSelectedShowRecommendedFilter,
     isInPopupView,
     clearFilters
 }) => {
@@ -113,20 +118,32 @@ export const SideNav: React.FC<IProps> = ({
                         </ResponsiveButton>
                         <ResponsiveButton
                             disabled={isInPopupView}
-                            $isSelected={isSelectedHideSequelFilter}
+                            $isSelected={isSelectedShowSequelFilter}
                             onClick={() => {
-                                setIsSelectedHideSequelFilter(
-                                    !isSelectedHideSequelFilter
+                                setIsSelectedShowSequelFilter(
+                                    !isSelectedShowSequelFilter
                                 );
                             }}
                         >
                             <LegendItemContainer>
                                 <IsSequelIcon size={35} />
-                                <LegendLabel>Hide Sequels</LegendLabel>
+                                <LegendLabel>Split off Sequels</LegendLabel>
                             </LegendItemContainer>
                         </ResponsiveButton>
                     </Row>
-
+                    <ResponsiveButton
+                        $isSelected={isSelectedShowRecommendedFilter}
+                        onClick={() =>
+                            setIsSelectedShowRecommendedFilter(
+                                !isSelectedShowRecommendedFilter
+                            )
+                        }
+                    >
+                        <LegendItemContainer>
+                            <StarIcon />
+                            <LegendLabel>Show Recommended</LegendLabel>
+                        </LegendItemContainer>
+                    </ResponsiveButton>
                     {miscellaneousSortingToolsList.map(sortingOption => {
                         return (
                             <SortByItem

--- a/src/views/SideNav/SideNav.tsx
+++ b/src/views/SideNav/SideNav.tsx
@@ -24,11 +24,8 @@ import { SortByItem } from './SortByItem';
 import { LegendItemContainer, LegendLabel, SIDE_NAV_WIDTH } from './utils';
 import { HasSequelIcon } from '../assets/icons/attribute/HasSequalIcon';
 import { IsSequelIcon } from '../assets/icons/attribute/IsSequelIcon';
-import {
-    Attribute,
-    GenreFocus,
-    PlaytimeLength
-} from '../HomePage/Chart/VisualNovelCard';
+import { Attribute, GenreFocus } from '../HomePage/Chart/utils';
+import { PlaytimeLength } from '../HomePage/Chart/utils';
 
 interface IProps {
     selectedSortingOptions: SortingOption[];

--- a/src/views/SideNav/SortByItem.tsx
+++ b/src/views/SideNav/SortByItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { SortingOption, SortingProps } from './LegendData';
+import { MiscellaneousSortingOption, SortingProps } from './LegendData';
 import { LegendItemContainer, LegendLabel } from './utils';
 import { ResponsiveButton } from '../utils';
 
 interface IProps extends SortingProps {
     isSelected: boolean;
-    onClick: (value: SortingOption) => void;
+    onClick: (value: MiscellaneousSortingOption) => void;
 }
 
 export const SortByItem: React.FC<IProps> = ({

--- a/src/views/assets/icons/misc/BookmarkIcon.tsx
+++ b/src/views/assets/icons/misc/BookmarkIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export const BookmarkIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="22"
+            height="22"
+            version="1.1"
+            viewBox="0 0 5.821 5.821"
+        >
+            <g>
+                <path
+                    fill="#fff"
+                    strokeWidth="0.265"
+                    d="M1.693.265A.634.634 0 001.058.9v4.656h.53V1.128c0-.185.149-.334.334-.334h1.977c.185 0 .334.149.334.334v4.428h.53V.9a.634.634 0 00-.636-.635z"
+                ></path>
+                <path
+                    fill="none"
+                    stroke="#fff"
+                    strokeDasharray="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="miter"
+                    strokeMiterlimit="4"
+                    strokeOpacity="1"
+                    strokeWidth="0.529"
+                    d="M1.323 5.556L2.91 3.97l1.588 1.587"
+                ></path>
+            </g>
+        </svg>
+    );
+};

--- a/src/views/assets/icons/misc/CloseIcon.tsx
+++ b/src/views/assets/icons/misc/CloseIcon.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export const CloseIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="22"
+            height="22"
+            version="1.1"
+            viewBox="0 0 5.821 5.821"
+        >
+            <g>
+                <circle
+                    cx="2.91"
+                    cy="2.91"
+                    r="2.381"
+                    fill="none"
+                    stroke="#fff"
+                    strokeDasharray="none"
+                    strokeMiterlimit="4"
+                    strokeWidth="0.529"
+                ></circle>
+                <rect
+                    width="0.529"
+                    height="3.175"
+                    x="3.851"
+                    y="-1.588"
+                    fill="#fff"
+                    strokeWidth="0.265"
+                    opacity="1"
+                    ry="0.265"
+                    transform="rotate(45)"
+                ></rect>
+                <rect
+                    width="0.529"
+                    height="3.175"
+                    x="-0.265"
+                    y="-5.703"
+                    fill="#fff"
+                    strokeWidth="0.265"
+                    opacity="1"
+                    ry="0.265"
+                    transform="rotate(135)"
+                ></rect>
+            </g>
+        </svg>
+    );
+};

--- a/src/views/assets/icons/misc/QuestionDiscIcon.tsx
+++ b/src/views/assets/icons/misc/QuestionDiscIcon.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export const QuestionDiscIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="22"
+            height="22"
+            version="1.1"
+            viewBox="0 0 5.821 5.821"
+        >
+            <g>
+                <path
+                    fill="#fff"
+                    fillOpacity="1"
+                    stroke="none"
+                    strokeWidth="2"
+                    d="M10.95 8A3 3 0 008 11a3 3 0 003 3 3 3 0 003-3 3 3 0 00-3-3 3 3 0 00-.05 0zM11 9.5a1.5 1.5 0 011.5 1.5 1.5 1.5 0 01-1.5 1.5A1.5 1.5 0 019.5 11 1.5 1.5 0 0111 9.5z"
+                    transform="scale(.26458)"
+                ></path>
+                <path
+                    fill="#fff"
+                    fillOpacity="1"
+                    stroke="none"
+                    strokeWidth="2"
+                    d="M10.98 5a6 6 0 00-.617.033l.158 1.492A4.5 4.5 0 0111 6.5a4.5 4.5 0 014.488 4.178l1.496-.108a6 6 0 00-2.134-4.174A6 6 0 0010.98 5z"
+                    transform="scale(.26458)"
+                ></path>
+                <path
+                    fill="#fff"
+                    fillOpacity="1"
+                    stroke="none"
+                    strokeWidth="2"
+                    d="M6.932 12.922l-1.358.64a6 6 0 003.852 3.227l.394-1.447a4.5 4.5 0 01-2.888-2.42z"
+                    transform="scale(.26458)"
+                ></path>
+                <path
+                    fill="#fefefe"
+                    fillOpacity="1"
+                    stroke="none"
+                    strokeWidth="2"
+                    d="M10.99 2a9 9 0 00-2.83.46c.296.417.524.879.65 1.368a7.5 7.5 0 012.153-.328 7.5 7.5 0 01.037 0 7.5 7.5 0 017.5 7.5 7.5 7.5 0 01-7.5 7.5 7.5 7.5 0 01-7.188-5.36H2.26A9 9 0 0011 20a9 9 0 009-9 9 9 0 00-9-9 9 9 0 00-.01 0z"
+                    transform="scale(.26458)"
+                ></path>
+                <g strokeWidth="0.265" transform="translate(.022)">
+                    <path
+                        d="M1.243 2.43H.804l-.002-.116q0-.214.071-.352.07-.137.282-.31.212-.172.254-.225.063-.085.063-.186 0-.142-.113-.242-.112-.101-.303-.101-.185 0-.309.105t-.17.32l-.445-.055Q.152.96.394.744.64.53 1.034.53q.418 0 .664.219.246.217.246.506 0 .16-.09.304-.09.142-.387.389-.153.127-.19.205-.037.077-.034.277zm-.439.65v-.484h.484v.484z"
+                        style={{}}
+                        fill="#fff"
+                        fillOpacity="1"
+                        strokeWidth="0.265"
+                        fontFamily="Arial"
+                        fontSize="3.528"
+                        fontStretch="normal"
+                        fontStyle="normal"
+                        fontVariant="normal"
+                        fontWeight="bold"
+                    ></path>
+                </g>
+            </g>
+        </svg>
+    );
+};

--- a/src/views/assets/icons/misc/QuestionStarIcon.tsx
+++ b/src/views/assets/icons/misc/QuestionStarIcon.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+export const QuestionStarIcon = () => {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="22"
+            height="22"
+            version="1.1"
+            viewBox="0 0 5.821 5.821"
+        >
+            <g>
+                <path
+                    style={{
+                        lineHeight: 'normal',
+                        fontVariantLigatures: 'normal',
+                        fontVariantPosition: 'normal',
+                        fontVariantCaps: 'normal',
+                        fontVariantNumeric: 'normal',
+                        fontVariantAlternates: 'normal',
+                        fontVariantEastAsian: 'normal',
+                        fontFeatureSettings: 'normal',
+                        fontVariationSettings: 'normal',
+                        textIndent: '0',
+                        textAlign: 'start',
+                        WebkitTextDecorationLine: 'none',
+                        textDecorationLine: 'none',
+                        WebkitTextDecorationStyle: 'solid',
+                        textDecorationStyle: 'solid',
+                        WebkitTextDecorationColor: '#000000',
+                        textDecorationColor: '#000000',
+                        textTransform: 'none',
+                        WebkitTextOrientation: 'mixed',
+                        textOrientation: 'mixed',
+                        whiteSpace: 'normal',
+                        shapeMargin: '0',
+                        inlineSize: '0',
+                        isolation: 'auto',
+                        mixBlendMode: 'normal'
+                    }}
+                    fill="#fff"
+                    fillOpacity="1"
+                    fillRule="nonzero"
+                    stroke="none"
+                    strokeDasharray="none"
+                    strokeDashoffset="0"
+                    strokeLinecap="butt"
+                    strokeLinejoin="miter"
+                    strokeMiterlimit="4"
+                    strokeOpacity="1"
+                    strokeWidth="2"
+                    d="M10.889.994L8.83 5.534c-.097.409-.256.804-.478 1.154v.007c-.04.063-.087.118-.13.178l-.326.719-.337.056c-.28.275-.594.55-.971.864-.127.105-.07.039-.133.11v1.29l2.766-.467 1.734-3.83 1.852 3.774 4.015.545-2.857 3.004.748 4.171-3.617-1.918L7.54 17.22l.625-4.192-1.71-1.69v1.804H5.43l.644.638L5.002 21l6.13-3.498 6.223 3.299-.36-2.035-.92-5.149 4.923-5.178-6.922-.945z"
+                    baselineShift="baseline"
+                    clipRule="nonzero"
+                    color="#000"
+                    colorInterpolation="sRGB"
+                    colorInterpolationFilters="linearRGB"
+                    colorRendering="auto"
+                    direction="ltr"
+                    display="inline"
+                    dominantBaseline="auto"
+                    enableBackground="accumulate"
+                    fontFamily="sans-serif"
+                    fontSize="medium"
+                    fontStretch="normal"
+                    fontStyle="normal"
+                    fontVariant="normal"
+                    fontWeight="normal"
+                    imageRendering="auto"
+                    letterSpacing="normal"
+                    opacity="1"
+                    overflow="visible"
+                    shapeRendering="auto"
+                    stopColor="#000"
+                    stopOpacity="1"
+                    textAnchor="start"
+                    textDecoration="none"
+                    textRendering="auto"
+                    transform="scale(.26458)"
+                    vectorEffect="none"
+                    visibility="visible"
+                    wordSpacing="normal"
+                    writingMode="lr-tb"
+                ></path>
+                <g strokeWidth="0.265" transform="translate(.022)">
+                    <path
+                        d="M1.243 2.43H.804l-.002-.116q0-.214.071-.352.07-.137.282-.31.212-.172.254-.225.063-.085.063-.186 0-.142-.113-.242-.112-.101-.303-.101-.185 0-.309.105t-.17.32l-.445-.055Q.152.96.394.744.64.53 1.034.53q.418 0 .664.219.246.217.246.506 0 .16-.09.304-.09.142-.387.389-.153.127-.19.205-.037.077-.034.277zm-.439.65v-.484h.484v.484z"
+                        style={{}}
+                        fill="#fff"
+                        fillOpacity="1"
+                        strokeWidth="0.265"
+                        fontFamily="Arial"
+                        fontSize="3.528"
+                        fontStretch="normal"
+                        fontStyle="normal"
+                        fontVariant="normal"
+                        fontWeight="bold"
+                    ></path>
+                </g>
+            </g>
+        </svg>
+    );
+};

--- a/src/views/utils.tsx
+++ b/src/views/utils.tsx
@@ -28,7 +28,7 @@ export const Row = styled.div<{
     ${({ $maxHeight }) =>
         $maxHeight
             ? css`
-                  height: 100vh;
+                  height: 100%;
               `
             : ''};
     ${({ $gap }) =>
@@ -64,7 +64,7 @@ export const COLOURS = {
 };
 
 const BaseFont = styled.div<{ $textAlign?: string }>`
-    font-family: sans-serif;
+    font-family: monospace;
     ${({ $textAlign }) =>
         $textAlign
             ? css`
@@ -74,6 +74,7 @@ const BaseFont = styled.div<{ $textAlign?: string }>`
 `;
 
 export const TitleFont = styled(BaseFont)<{ $fontColour?: string }>`
+    font-family: sans-serif;
     font-size: 1.3rem;
     width: 250px;
     white-space: nowrap;

--- a/src/views/utils.tsx
+++ b/src/views/utils.tsx
@@ -152,12 +152,36 @@ export const StaggeredEntranceFade: React.FC<{
                 opacity: 1,
                 x: 0,
                 y: 0,
-                transition: { duration: Math.min(0.1 * index, 2) }
+                transition: { duration: Math.min(0.1 * (index + 1), 2) }
             }}
             exit={{
                 opacity: 0,
                 x: 40,
                 y: -40,
+                transition: { duration: 0.4 }
+            }}
+        >
+            {children}
+        </motion.div>
+    );
+};
+
+export const StaggeredEntranceFadeSlow: React.FC<{
+    children?: React.ReactNode | undefined;
+    index: number;
+}> = ({ children, index }) => {
+    return (
+        <motion.div
+            initial={{ opacity: 0, y: -400 }}
+            animate={{
+                opacity: 1,
+                x: 0,
+                y: 0,
+                transition: { duration: 0.25 * (index + 1) }
+            }}
+            exit={{
+                opacity: 0,
+                y: -400,
                 transition: { duration: 0.4 }
             }}
         >


### PR DESCRIPTION
Changes:
- Scrolling between upcoming and current releases now works even when `Hide Sequels` is enabled
- Sequels popup now animates
- Icons have more isolated background colouring
- Card size shrinks dynamically with stack count
- Add new section for recommended VNs
  - Clicking on a show more icon opens up a popup with a short description.
- Scale image sizes based on # of cards in a stack
- Fandiscs can display the recommended icon in the sequel popup
- Updated font

Screenshots:
Recommended section
![image](https://github.com/chartanon/moechart/assets/87510981/af431b8c-d575-4ea2-8d06-8bba43117c0c)

Recommended popup
![image](https://github.com/chartanon/moechart/assets/87510981/035980bc-1b27-4293-aac0-056c9b86e2cd)
